### PR TITLE
Make options.path default to false

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ module.exports = function (options) {
 	var datadog = options.dogstatsd || new DD();
 	var stat = options.stat || "node.express.router";
 	var tags = options.tags || [];
+	var options.path = options.path || false;
 	var response_code = options.response_code || false;
 
 	return function (req, res, next) {
@@ -27,7 +28,6 @@ module.exports = function (options) {
 			if (options.method) {
 				statTags.push("method:" + req.method.toLowerCase());
 			}
-
 
 			if (options.protocol && req.protocol) {
 				statTags.push("protocol:" + req.protocol);


### PR DESCRIPTION
By having this default to only matching false (ie !==) it will send the path by default.
This loaded up our metrics with a huge amount of tags (we have a lot of unique get paths).

All the change does is make it the default to not send the path tag. 
I know it changes the default behavior but seems to be a more sane default...
