### PR TITLE
Update node-dogstatsd to support SmartOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
 	"license": "MIT",
 	"readmeFilename": "README.md",
 	"dependencies": {
-		"node-dogstatsd": "0.0.5"
+		"node-dogstatsd": "0.0.6"
 	}
 }


### PR DESCRIPTION
dogstatsd was only js, there was no reason to be platform specific, they remove the check in their package.json
