### PR TITLE
Pipe character bug fix with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ All options are optional.
 * `stat` *string* name for the stat. `default = "node.express.router"`
 * `tags` *array* of tags to be added to the histogram. `default = []`
 * `path` *boolean* include path tag. `default = false`
+* `base_url` *boolean* include baseUrl. `default = false`
 * `method` *boolean* include http method tag. `default = false`
 * `protocol` *boolean* include protocol tag. `default = false`
 * `response_code` *boolean* include http response codes. `default = false`
+* `delim` *string* char to replace pipe char with in the route `default = '-'`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ All options are optional.
 * `dogstatsd` node-dogstatsd client. `default = new require("node-dogstatsd").StatsD()`
 * `stat` *string* name for the stat. `default = "node.express.router"`
 * `tags` *array* of tags to be added to the histogram. `default = []`
-* `path` *boolean* include path tag. `default = true`
+* `path` *boolean* include path tag. `default = false`
 * `method` *boolean* include http method tag. `default = false`
 * `protocol` *boolean* include protocol tag. `default = false`
 * `response_code` *boolean* include http response codes. `default = false`

--- a/lib/index.js
+++ b/lib/index.js
@@ -41,7 +41,7 @@ module.exports = function (options) {
 
 			let statTags = [`route:${replacePipeChar(req.route.path)}`].concat(tags);
 
-			if (options.method) {
+			if (method !== false) {
 				statTags.push(`method:${req.method.toLowerCase()}`);
 			}
 
@@ -51,10 +51,6 @@ module.exports = function (options) {
 
 			if (path !== false) {
 				statTags.push(`path:${req.path}`);
-			}
-
-			if (method !== false) {
-				statTags.push(`method:${req.method}`);
 			}
 
 			if (response_code) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,19 +10,18 @@ module.exports = function (options) {
 	let REGEX_PIPE = /\|/g;
 
 	/**
-	 * Checks if reqPath is a regular expression and stringifies it if it is.
+	 * Checks if str is a regular expression and stringifies it if it is.
 	 * Returns a string with all instances of the pipe character replaced with
-	 * the delimiter. Datadog does not support pipe characters in the metric string.
-	 * @param  {*}       reqPath  The request path
-	 *
-	 * @return {string}           The request path with pipe chars replaced
+	 * the delimiter.
+	 * @param  {*}       str  The string to check for pipe chars
+	 * @return {string}       The input string with pipe chars replaced
 	 */
-	function replacePipeChar(reqPath) {
-		if (reqPath instanceof RegExp) {
-			reqPath = reqPath.toString();
+	function replacePipeChar(str) {
+		if (str instanceof RegExp) {
+			str = str.toString();
 		}
 
-		return reqPath && reqPath.replace(REGEX_PIPE, DELIM);
+		return str && str.replace(REGEX_PIPE, DELIM);
 	}
 
 	return function (req, res, next) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ module.exports = function (options) {
 	var datadog = options.dogstatsd || new DD();
 	var stat = options.stat || "node.express.router";
 	var tags = options.tags || [];
+	var options.path = options.path || false;
 	var response_code = options.response_code || false;
 
 	return function (req, res, next) {
@@ -27,7 +28,6 @@ module.exports = function (options) {
 			if (options.method) {
 				statTags.push("method:" + req.method.toLowerCase());
 			}
-
 
 			if (options.protocol && req.protocol) {
 				statTags.push("protocol:" + req.protocol);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,18 +1,18 @@
-var DD = require("node-dogstatsd").StatsD;
+const DD = require("node-dogstatsd").StatsD;
 
 module.exports = function (options) {
-	var datadog = options.dogstatsd || new DD();
-	var stat = options.stat || "node.express.router";
-	var tags = options.tags || [];
-	var options.path = options.path || false;
-	var response_code = options.response_code || false;
+	let datadog = options.dogstatsd || new DD();
+	let stat = options.stat || "node.express.router";
+	let tags = options.tags || [];
+	let path = options.path || false;
+	let response_code = options.response_code || false;
 
 	return function (req, res, next) {
 		if (!req._startTime) {
 			req._startTime = new Date();
 		}
 
-		var end = res.end;
+		let end = res.end;
 		res.end = function (chunk, encoding) {
 			res.end = end;
 			res.end(chunk, encoding);
@@ -21,29 +21,27 @@ module.exports = function (options) {
 				return;
 			}
 
-			var statTags = [
-				"route:" + req.route.path
-			].concat(tags);
+			let statTags = [`route:${req.route.path}`].concat(tags);
 
 			if (options.method) {
-				statTags.push("method:" + req.method.toLowerCase());
+				statTags.push(`method:${req.method.toLowerCase()}`)
 			}
 
 			if (options.protocol && req.protocol) {
-				statTags.push("protocol:" + req.protocol);
+				statTags.push(`protocol:${req.protocol}`)
 			}
 
-			if (options.path !== false) {
-				statTags.push("path:" + req.path);
+			if (path !== false) {
+				statTags.push(`path:${req.path}`)
 			}
 
 			if (response_code) {
-				statTags.push("response_code:" + res.statusCode);
-				datadog.increment(stat + '.response_code.' + res.statusCode , 1, statTags);
-				datadog.increment(stat + '.response_code.all' , 1, statTags);
+				statTags.push(`response_code:${res.statusCode}`);
+				datadog.increment(`${stat}.response_code.${res.statusCode}`, 1, statTags);
+				datadog.increment(`${stat}.response_code.all`, 1, statTags);
 			}
 
-			datadog.histogram(stat + '.response_time', (new Date() - req._startTime), 1, statTags);
+			datadog.histogram(`${stat}.response_time`, new Date() - req._startTime, 1, statTags);
 		};
 
 		next();

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,9 @@ module.exports = function (options) {
 	let stat = options.stat || "node.express.router";
 	let tags = options.tags || [];
 	let path = options.path || false;
+	let base_url = options.base_url || false;
 	let method = options.method || false;
+	let protocol = options.protocol || false;
 	let response_code = options.response_code || false;
 	let DELIM = options.delim || '-';
 	let REGEX_PIPE = /\|/g;
@@ -39,13 +41,14 @@ module.exports = function (options) {
 				return;
 			}
 
-			let statTags = [`route:${replacePipeChar(req.route.path)}`].concat(tags);
+			const baseUrl = (base_url !== false) ? req.baseUrl : '';
+			let statTags = [`route:${baseUrl + replacePipeChar(req.route.path)}`].concat(tags);
 
 			if (method !== false) {
 				statTags.push(`method:${req.method.toLowerCase()}`);
 			}
 
-			if (options.protocol && req.protocol) {
+			if (protocol && req.protocol) {
 				statTags.push(`protocol:${req.protocol}`);
 			}
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,22 @@ module.exports = function (options) {
 	let tags = options.tags || [];
 	let path = options.path || false;
 	let response_code = options.response_code || false;
+	let DELIM = options.delim || '-';
+	let REGEX_PIPE = /\|/g;
+
+  /**
+	 * Returns a metric string with all instances of the pipe character
+	 * replaced with the delimiter. Datadog does not support pipe characters
+	 * in the metric string.
+	 * @param {*} str
+	 */
+	function replacePipeChar(str) {
+		if (str instanceof RegExp) {
+			str = str.toString();
+		}
+
+		return str && str.replace(REGEX_PIPE, DELIM);
+	}
 
 	return function (req, res, next) {
 		if (!req._startTime) {
@@ -21,18 +37,18 @@ module.exports = function (options) {
 				return;
 			}
 
-			let statTags = [`route:${req.route.path}`].concat(tags);
+			let statTags = [`route:${replacePipeChar(req.route.path)}`].concat(tags);
 
 			if (options.method) {
-				statTags.push(`method:${req.method.toLowerCase()}`)
+				statTags.push(`method:${req.method.toLowerCase()}`);
 			}
 
 			if (options.protocol && req.protocol) {
-				statTags.push(`protocol:${req.protocol}`)
+				statTags.push(`protocol:${req.protocol}`);
 			}
 
 			if (path !== false) {
-				statTags.push(`path:${req.path}`)
+				statTags.push(`path:${req.path}`);
 			}
 
 			if (response_code) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,18 +9,20 @@ module.exports = function (options) {
 	let DELIM = options.delim || '-';
 	let REGEX_PIPE = /\|/g;
 
-  /**
-	 * Returns a metric string with all instances of the pipe character
-	 * replaced with the delimiter. Datadog does not support pipe characters
-	 * in the metric string.
-	 * @param {*} str
+	/**
+	 * Checks if reqPath is a regular expression and stringifies it if it is.
+	 * Returns a string with all instances of the pipe character replaced with
+	 * the delimiter. Datadog does not support pipe characters in the metric string.
+	 * @param  {*}       reqPath  The request path
+	 *
+	 * @return {string}           The request path with pipe chars replaced
 	 */
-	function replacePipeChar(str) {
-		if (str instanceof RegExp) {
-			str = str.toString();
+	function replacePipeChar(reqPath) {
+		if (reqPath instanceof RegExp) {
+			reqPath = reqPath.toString();
 		}
 
-		return str && str.replace(REGEX_PIPE, DELIM);
+		return reqPath && reqPath.replace(REGEX_PIPE, DELIM);
 	}
 
 	return function (req, res, next) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@ module.exports = function (options) {
 	let stat = options.stat || "node.express.router";
 	let tags = options.tags || [];
 	let path = options.path || false;
+	let method = options.method || false;
 	let response_code = options.response_code || false;
 	let DELIM = options.delim || '-';
 	let REGEX_PIPE = /\|/g;
@@ -50,6 +51,10 @@ module.exports = function (options) {
 
 			if (path !== false) {
 				statTags.push(`path:${req.path}`);
+			}
+
+			if (method !== false) {
+				statTags.push(`method:${req.method}`);
 			}
 
 			if (response_code) {

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -202,8 +202,19 @@ describe('connectDatadog', () => {
           expectConnectedToDatadog(stat, statTags)
         })
       })
+
+      describe('when the path is not set in the request', () => {
+        it('should NOT send a response', async () => {
+          req = {}
+
+          await asyncConnectDatadogAndCallMiddleware({})
+          expect(mockStatsDImplementation.increment).not.toHaveBeenCalled()
+          expect(mockStatsDImplementation.histogram).not.toHaveBeenCalled()
+          expect(next).toHaveBeenCalled()
+        })
+      })
     })
-    
+
     describe('response_code', () => {
       describe('when the response_code option is truthy', () => {
         it('should send metrics for the response_code', async () => {

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -22,6 +22,7 @@ describe('connectDatadog', () => {
       route: { path: '/some/path' },
       path: '/another/path',
       method: 'GET',
+      baseUrl: 'http://www.fakeurl.com',
     }
     res = {
       status: jest.fn().mockReturnThis(),
@@ -211,6 +212,47 @@ describe('connectDatadog', () => {
           expect(mockStatsDImplementation.increment).not.toHaveBeenCalled()
           expect(mockStatsDImplementation.histogram).not.toHaveBeenCalled()
           expect(next).toHaveBeenCalled()
+        })
+      })
+    })
+
+    describe('base_url', () => {
+      describe('when the base_url option is truthy', () => {
+        it('should append the baseUrl to the beginning of the route in the metric tag', () => {
+          const base_url = true
+          const stat = 'node.express.router'
+          const statTags = [
+            `route:${req.baseUrl}${req.route.path}`,
+            `response_code:${res.statusCode}`,
+          ]
+
+          asyncConnectDatadogAndCallMiddleware({
+            response_code: true,
+            base_url,
+          })
+          expectConnectedToDatadog(stat, statTags)
+        })
+      })
+
+      describe('when the base_url option is falsy', () => {
+        it('should NOT append the baseUrl to the beginning of the route in the metric tag', () => {
+          const base_url = false
+          const stat = 'node.express.router'
+          const statTags = [
+            `route:${req.route.path}`,
+            `response_code:${res.statusCode}`,
+          ]
+
+          // base_url option is explicitly set to false
+          asyncConnectDatadogAndCallMiddleware({
+            response_code: true,
+            base_url,
+          })
+          expectConnectedToDatadog(stat, statTags)
+
+          // default base_url option is used
+          asyncConnectDatadogAndCallMiddleware({ response_code: true })
+          expectConnectedToDatadog(stat, statTags)
         })
       })
     })

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -203,54 +203,7 @@ describe('connectDatadog', () => {
         })
       })
     })
-
-    describe('method', () => {
-      describe('when the method option is truthy', () => {
-        it('should append the method to the metric tag', async () => {
-          const method = true
-          const stat = 'node.express.router'
-          const statTags = [
-            `route:${req.route.path}`,
-            `response_code:${res.statusCode}`,
-            `method:${req.method}`,
-          ]
-
-          await asyncConnectDatadogAndCallMiddleware({ response_code: true, method })
-          expectConnectedToDatadog(stat, statTags, false)
-        })
-      })
-
-      describe('when the method option is falsy', () => {
-        it('should NOT append the method to the metric tag', async () => {
-          const method = false
-          const stat = 'node.express.router'
-          const statTags = [
-            `route:${req.route.path}`,
-            `response_code:${res.statusCode}`,
-          ]
-
-          // method option is explicitly set to false
-          await asyncConnectDatadogAndCallMiddleware({ response_code: true, method })
-          expectConnectedToDatadog(stat, statTags)
-
-          // default method option is used
-          await asyncConnectDatadogAndCallMiddleware({ response_code: true })
-          expectConnectedToDatadog(stat, statTags)
-        })
-      })
-
-      describe('when the path is not set in the request', () => {
-        it('should NOT send a response', async () => {
-          req = {}
-
-          await asyncConnectDatadogAndCallMiddleware({})
-          expect(mockStatsDImplementation.increment).not.toHaveBeenCalled()
-          expect(mockStatsDImplementation.histogram).not.toHaveBeenCalled()
-          expect(next).toHaveBeenCalled()
-        })
-      })
-    })
-
+    
     describe('response_code', () => {
       describe('when the response_code option is truthy', () => {
         it('should send metrics for the response_code', async () => {

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -315,10 +315,6 @@ describe('connectDatadog', () => {
     })
 
     describe('method', () => {
-      beforeEach(() => {
-        req.method = 'POST'
-      })
-
       describe('when the method option is truthy', () => {
         it('should append the req.method to the metric tags', async () => {
           const method = true

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -1,0 +1,435 @@
+const connectDatadog = require("./index");
+
+const mockStatsDImplementation = {
+  histogram: jest.fn(),
+  increment: jest.fn(),
+}
+
+jest.mock('node-dogstatsd', () => ({
+  StatsD: jest.fn().mockImplementation(() => mockStatsDImplementation),
+}))
+
+describe('connectDatadog', () => {
+  let req
+  let res
+  let next
+
+  const chunk = '<p>Here is a chunk</p>'
+  const encoding = 'text/html'
+
+  beforeEach(() => {
+    req = {
+      route: { path: '/some/path' },
+      path: '/another/path',
+    }
+    res = {
+      status: jest.fn().mockReturnThis(),
+      send: jest.fn().mockReturnThis(),
+      end: jest.fn().mockReturnThis(),
+      statusCode: 200,
+    }
+    next = jest.fn()
+  })
+
+  afterEach(() => {
+    mockStatsDImplementation.histogram.mockReset()
+    mockStatsDImplementation.increment.mockReset()
+  })
+
+  const asyncConnectDatadogAndCallMiddleware = (options, timeoutInterval = 0) =>
+    new Promise(resolve => {
+      const middleware = connectDatadog(options)
+      middleware(req, res, next)
+
+      timeoutInterval > 0
+        ? setTimeout(() => resolve(res.end(chunk, encoding)), timeoutInterval)
+        : (res.end(chunk, encoding), resolve())
+    })
+
+  const expectConnectedToDatadog = (stat, statTags, exactMatch = true) => {
+    const checkStatTags = exactMatch
+      ? statTags
+      : expect.arrayContaining(statTags)
+
+    expect(mockStatsDImplementation.histogram).toHaveBeenCalledWith(
+      `${stat}.response_time`,
+      expect.anything(),
+      1,
+      checkStatTags
+    )
+    expect(mockStatsDImplementation.increment).toHaveBeenCalledWith(
+      `${stat}.response_code.${res.statusCode}`,
+      1,
+      checkStatTags
+    )
+    expect(mockStatsDImplementation.increment).toHaveBeenCalledWith(
+      `${stat}.response_code.all`,
+      1,
+      checkStatTags
+    )
+    expect(next).toHaveBeenCalled()
+  }
+
+  describe('middleware', () => {
+    it('calls next', () => {
+      const middleware = connectDatadog({})
+
+      middleware(req, res, next)
+      expect(next).toHaveBeenCalled()
+    })
+  })
+
+  describe('when res.end is called', () => {
+    it('calls the original res.end', async () => {
+      // connectDatadog monkey-patches res.end, so we need to test that the original one is called
+      const originalEnd = res.end
+
+      await asyncConnectDatadogAndCallMiddleware({})
+      expect(originalEnd).toHaveBeenCalled()
+    })
+
+    it('should update the histogram', async () => {
+      await asyncConnectDatadogAndCallMiddleware({})
+      expect(mockStatsDImplementation.histogram).toHaveBeenCalled()
+    })
+  })
+
+  describe('when options are passed to the closure', () => {
+    describe('new dogstatsd object', () => {
+      let dogstatsd
+
+      beforeEach(() => {
+        dogstatsd = { histogram: jest.fn() }
+      })
+
+      it('gets a value for the dogstatsd option', async () => {
+        await asyncConnectDatadogAndCallMiddleware({ dogstatsd })
+        expect(dogstatsd.histogram).toHaveBeenCalled()
+      })
+
+      it('uses the default value for the dogstatsd option if not passed', async () => {
+        await asyncConnectDatadogAndCallMiddleware({})
+        expect(mockStatsDImplementation.histogram).toHaveBeenCalled()
+        expect(dogstatsd.histogram).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('stat', () => {
+      describe('when the stat option is passed', () => {
+        it('should send a metric name with the passed value', async () => {
+          const stat = 'foo'
+          const statTags = expect.anything()
+
+          await asyncConnectDatadogAndCallMiddleware({ stat, response_code: true })
+          expectConnectedToDatadog(stat, statTags)
+        })
+      })
+
+      describe('when the stat option is not passed', () => {
+        it('should send a metric name with the default value', async () => {
+          const stat = 'node.express.router'
+          const statTags = expect.anything()
+
+          await asyncConnectDatadogAndCallMiddleware({ response_code: true })
+          expectConnectedToDatadog(stat, statTags)
+        })
+      })
+    })
+
+    describe('tags', () => {
+      describe('when the tags option is passed', () => {
+        describe('when the tags option is a list of tags', () => {
+          it('should append a list of tags to the metric tag', async () => {
+            const stat = 'node.express.router'
+            const tags = ['foo:bar', 'baz:ball']
+            const statTags = [
+              `route:${req.route.path}`,
+              `response_code:${res.statusCode}`,
+            ].concat(tags)
+
+            await asyncConnectDatadogAndCallMiddleware({ response_code: true, tags })
+            expectConnectedToDatadog(stat, statTags, false)
+          })
+        })
+      })
+
+      describe('when the tags option is not passed', () => {
+        it('uses the default value for the tags option if not passed', async () => {
+          const stat = 'node.express.router'
+          const statTags = [
+            `route:${req.route.path}`,
+            `response_code:${res.statusCode}`,
+          ]
+
+          await asyncConnectDatadogAndCallMiddleware({ response_code: true })
+          expectConnectedToDatadog(stat, statTags)
+        })
+      })
+    })
+
+    describe('path', () => {
+      describe('when the path option is truthy', () => {
+        it('should append the path to the metric tag', async () => {
+          const path = true
+          const stat = 'node.express.router'
+          const statTags = [
+            `route:${req.route.path}`,
+            `response_code:${res.statusCode}`,
+            `path:${req.path}`,
+          ]
+
+          await asyncConnectDatadogAndCallMiddleware({ response_code: true, path })
+          expectConnectedToDatadog(stat, statTags, false)
+        })
+      })
+
+      describe('when the path option is falsy', () => {
+        it('should NOT append the path to the metric tag', async () => {
+          const path = false
+          const stat = 'node.express.router'
+          const statTags = [
+            `route:${req.route.path}`,
+            `response_code:${res.statusCode}`,
+          ]
+
+          // path option is explicitly set to false
+          await asyncConnectDatadogAndCallMiddleware({ response_code: true, path })
+          expectConnectedToDatadog(stat, statTags)
+
+          // default path option is used
+          await asyncConnectDatadogAndCallMiddleware({ response_code: true })
+          expectConnectedToDatadog(stat, statTags)
+        })
+      })
+
+      describe('when the path is not set in the request', () => {
+        it('should NOT send a response', async () => {
+          req = {}
+
+          await asyncConnectDatadogAndCallMiddleware({})
+          expect(mockStatsDImplementation.increment).not.toHaveBeenCalled()
+          expect(mockStatsDImplementation.histogram).not.toHaveBeenCalled()
+          expect(next).toHaveBeenCalled()
+        })
+      })
+    })
+
+    describe('response_code', () => {
+      describe('when the response_code option is truthy', () => {
+        it('should send metrics for the response_code', async () => {
+          const response_code = true
+
+          await asyncConnectDatadogAndCallMiddleware({ response_code })
+          expect(mockStatsDImplementation.increment).toHaveBeenCalledTimes(2)
+          expect(mockStatsDImplementation.histogram).toHaveBeenCalled()
+        })
+      })
+
+      describe('when the response_code option is falsy', () => {
+        it('should NOT send metrics for the response_code', async () => {
+          const response_code = false
+
+          // response_code option is explicitly set to false
+          await asyncConnectDatadogAndCallMiddleware({ response_code })
+          expect(mockStatsDImplementation.increment).not.toHaveBeenCalled()
+          expect(mockStatsDImplementation.histogram).toHaveBeenCalled()
+
+          // default response_code option is used
+          await asyncConnectDatadogAndCallMiddleware({})
+          expect(mockStatsDImplementation.increment).not.toHaveBeenCalled()
+          expect(mockStatsDImplementation.histogram).toHaveBeenCalled()
+        })
+      })
+    })
+
+    describe('delim', () => {
+      describe('when the route contains a pipe character', () => {
+        describe('when the delim option is passed', () => {
+          it('should replace the pipe character', async () => {
+            const delim = 'x'
+            const origRoute = '/route|with|pipe'
+            const routeWithoutPipes = `/route${delim}with${delim}pipe`
+            req.route.path = origRoute
+            const stat = 'node.express.router'
+            const statTags = [`route:${routeWithoutPipes}`]
+
+            await asyncConnectDatadogAndCallMiddleware({ delim })
+            expect(mockStatsDImplementation.histogram).toHaveBeenCalledWith(
+              `${stat}.response_time`,
+              expect.anything(),
+              1,
+              statTags
+            )
+          })
+        })
+
+        describe('when the delim option is NOT passed', () => {
+          it('should use the default delim', async () => {
+            const origRoute = '/route|with|pipe'
+            const routeWithoutPipes = '/route-with-pipe' // The default delim should be '-'
+            req.route.path = origRoute
+            const stat = 'node.express.router'
+            const statTags = [`route:${routeWithoutPipes}`]
+
+            await asyncConnectDatadogAndCallMiddleware({})
+            expect(mockStatsDImplementation.histogram).toHaveBeenCalledWith(
+              `${stat}.response_time`,
+              expect.anything(),
+              1,
+              statTags
+            )
+          })
+        })
+      })
+
+      describe('when the route does NOT contain a pipe character', () => {
+        it('should not change the route', async () => {
+          const origRoute = '/route_with_pipe'
+          req.route.path = origRoute
+          const stat = 'node.express.router'
+          const statTags = [`route:${origRoute}`]
+
+          await asyncConnectDatadogAndCallMiddleware({})
+          expect(mockStatsDImplementation.histogram).toHaveBeenCalledWith(
+            `${stat}.response_time`,
+            expect.anything(),
+            1,
+            statTags
+          )
+        })
+      })
+    })
+
+    describe('response_time', () => {
+      const TIME_TO_WAIT = 50
+
+      it('should send a valid response_time metric greater than 0', async () => {
+        await asyncConnectDatadogAndCallMiddleware({}, TIME_TO_WAIT)
+
+        const expectedResponseTime =
+          mockStatsDImplementation.histogram.mock.calls[0][1]
+        expect(mockStatsDImplementation.histogram).toHaveBeenCalled()
+        expect(expectedResponseTime).toBeGreaterThanOrEqual(TIME_TO_WAIT)
+      })
+    })
+
+    describe('method', () => {
+      beforeEach(() => {
+        req.method = 'POST'
+      })
+
+      describe('when the method option is truthy', () => {
+        it('should append the req.method to the metric tags', async () => {
+          const method = true
+          const stat = 'node.express.router'
+          const statTags = [
+            `route:${req.route.path}`,
+            `response_code:${res.statusCode}`,
+            `method:${req.method.toLowerCase()}`,
+          ]
+
+          await asyncConnectDatadogAndCallMiddleware({ response_code: true, method })
+          expectConnectedToDatadog(stat, statTags, false)
+        })
+      })
+
+      describe('when the method option is falsy', () => {
+        it('should not append the req.method to the metric tags', async () => {
+          const method = false
+          const stat = 'node.express.router'
+          const statTags = [
+            `route:${req.route.path}`,
+            `response_code:${res.statusCode}`,
+          ]
+
+          // method option is explicitly set to false
+          await asyncConnectDatadogAndCallMiddleware({ response_code: true, method })
+          expectConnectedToDatadog(stat, statTags, false)
+
+          // no method option is passed
+          await asyncConnectDatadogAndCallMiddleware({ response_code: true })
+          expectConnectedToDatadog(stat, statTags, false)
+        })
+      })
+    })
+
+    describe('protocol', () => {
+      describe('when the protocol option is truthy', () => {
+        it('should append req.protocol to the metric tags if req.protocol is defined', async () => {
+          const protocol = true
+          req.protocol = 'fake protocol'
+          const stat = 'node.express.router'
+          const statTags = [
+            `route:${req.route.path}`,
+            `response_code:${res.statusCode}`,
+            `protocol:${req.protocol}`,
+          ]
+
+          await asyncConnectDatadogAndCallMiddleware({
+            response_code: true,
+            protocol,
+          })
+          expectConnectedToDatadog(stat, statTags, false)
+        })
+
+        it('should still send metrics if req.protocol is NOT defined', async () => {
+          const protocol = true
+          const stat = 'node.express.router'
+          const statTags = [
+            `route:${req.route.path}`,
+            `response_code:${res.statusCode}`,
+          ]
+
+          await asyncConnectDatadogAndCallMiddleware({
+            response_code: true,
+            protocol,
+          })
+          expectConnectedToDatadog(stat, statTags)
+        })
+      })
+
+      describe('when the protocol option is falsy', () => {
+        it('should NOT append req.protocol to the metric tags if req.protocol is defined', async () => {
+          const protocol = false
+          req.protocol = 'fake protocol'
+          const stat = 'node.express.router'
+          const statTags = [
+            `route:${req.route.path}`,
+            `response_code:${res.statusCode}`,
+          ]
+
+          // protocol option is explicitly set to false
+          await asyncConnectDatadogAndCallMiddleware({
+            response_code: true,
+            protocol,
+          })
+          expectConnectedToDatadog(stat, statTags)
+
+          // no protocol option is set
+          await asyncConnectDatadogAndCallMiddleware({ response_code: true })
+          expectConnectedToDatadog(stat, statTags)
+        })
+
+        it('should still send metrics if req.protocol is NOT defined', async () => {
+          const protocol = false
+          const stat = 'node.express.router'
+          const statTags = [
+            `route:${req.route.path}`,
+            `response_code:${res.statusCode}`,
+          ]
+
+          // protocol option is explicitly set to false
+          await asyncConnectDatadogAndCallMiddleware({
+            response_code: true,
+            protocol,
+          })
+          expectConnectedToDatadog(stat, statTags)
+
+          // no protocol option is set
+          await asyncConnectDatadogAndCallMiddleware({ response_code: true })
+          expectConnectedToDatadog(stat, statTags)
+        })
+      })
+    })
+  })
+})

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -21,6 +21,7 @@ describe('connectDatadog', () => {
     req = {
       route: { path: '/some/path' },
       path: '/another/path',
+      method: 'GET',
     }
     res = {
       status: jest.fn().mockReturnThis(),
@@ -197,6 +198,42 @@ describe('connectDatadog', () => {
           expectConnectedToDatadog(stat, statTags)
 
           // default path option is used
+          await asyncConnectDatadogAndCallMiddleware({ response_code: true })
+          expectConnectedToDatadog(stat, statTags)
+        })
+      })
+    })
+
+    describe('method', () => {
+      describe('when the method option is truthy', () => {
+        it('should append the method to the metric tag', async () => {
+          const method = true
+          const stat = 'node.express.router'
+          const statTags = [
+            `route:${req.route.path}`,
+            `response_code:${res.statusCode}`,
+            `method:${req.method}`,
+          ]
+
+          await asyncConnectDatadogAndCallMiddleware({ response_code: true, method })
+          expectConnectedToDatadog(stat, statTags, false)
+        })
+      })
+
+      describe('when the method option is falsy', () => {
+        it('should NOT append the method to the metric tag', async () => {
+          const method = false
+          const stat = 'node.express.router'
+          const statTags = [
+            `route:${req.route.path}`,
+            `response_code:${res.statusCode}`,
+          ]
+
+          // method option is explicitly set to false
+          await asyncConnectDatadogAndCallMiddleware({ response_code: true, method })
+          expectConnectedToDatadog(stat, statTags)
+
+          // default method option is used
           await asyncConnectDatadogAndCallMiddleware({ response_code: true })
           expectConnectedToDatadog(stat, statTags)
         })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,4459 @@
+{
+	"name": "connect-datadog",
+	"version": "0.0.7",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"@babel/code-frame": {
+			"version": "7.0.0-beta.40",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.40.tgz",
+			"integrity": "sha512-eVXQSbu/RimU6OKcK2/gDJVTFcxXJI4sHbIqw2mhwMZeQ2as/8AhS9DGkEDoHMBBNJZ5B0US63lF56x+KDcxiA==",
+			"dev": true,
+			"requires": {
+				"@babel/highlight": "7.0.0-beta.40"
+			}
+		},
+		"@babel/highlight": {
+			"version": "7.0.0-beta.40",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.40.tgz",
+			"integrity": "sha512-mOhhTrzieV6VO7odgzFGFapiwRK0ei8RZRhfzHhb6cpX3QM8XXuCLXWjN8qBB7JReDdUR80V3LFfFrGUYevhNg==",
+			"dev": true,
+			"requires": {
+				"chalk": "2.3.1",
+				"esutils": "2.0.2",
+				"js-tokens": "3.0.2"
+			}
+		},
+		"abab": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
+			"integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
+			"dev": true
+		},
+		"acorn": {
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
+			"integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ==",
+			"dev": true
+		},
+		"acorn-globals": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
+			"integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
+			"dev": true,
+			"requires": {
+				"acorn": "5.4.1"
+			}
+		},
+		"ajv": {
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+			"dev": true,
+			"requires": {
+				"co": "4.6.0",
+				"fast-deep-equal": "1.1.0",
+				"fast-json-stable-stringify": "2.0.0",
+				"json-schema-traverse": "0.3.1"
+			}
+		},
+		"align-text": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+			"dev": true,
+			"requires": {
+				"kind-of": "3.2.2",
+				"longest": "1.0.1",
+				"repeat-string": "1.6.1"
+			}
+		},
+		"amdefine": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+			"dev": true
+		},
+		"ansi-escapes": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
+			"integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+			"dev": true
+		},
+		"ansi-regex": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+			"dev": true
+		},
+		"ansi-styles": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+			"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+			"dev": true,
+			"requires": {
+				"color-convert": "1.9.1"
+			}
+		},
+		"anymatch": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+			"dev": true,
+			"requires": {
+				"micromatch": "2.3.11",
+				"normalize-path": "2.1.1"
+			}
+		},
+		"append-transform": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
+			"integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+			"dev": true,
+			"requires": {
+				"default-require-extensions": "1.0.0"
+			}
+		},
+		"argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
+			"requires": {
+				"sprintf-js": "1.0.3"
+			}
+		},
+		"arr-diff": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+			"dev": true,
+			"requires": {
+				"arr-flatten": "1.1.0"
+			}
+		},
+		"arr-flatten": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+			"dev": true
+		},
+		"array-equal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+			"dev": true
+		},
+		"array-unique": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+			"dev": true
+		},
+		"arrify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+			"dev": true
+		},
+		"asn1": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+			"dev": true
+		},
+		"assert-plus": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+			"dev": true
+		},
+		"astral-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+			"dev": true
+		},
+		"async": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+			"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+			"dev": true,
+			"requires": {
+				"lodash": "4.17.5"
+			}
+		},
+		"async-limiter": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+			"dev": true
+		},
+		"asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+			"dev": true
+		},
+		"aws-sign2": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+			"dev": true
+		},
+		"aws4": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+			"dev": true
+		},
+		"babel-code-frame": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"esutils": "2.0.2",
+				"js-tokens": "3.0.2"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
+				}
+			}
+		},
+		"babel-core": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
+			"integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+			"dev": true,
+			"requires": {
+				"babel-code-frame": "6.26.0",
+				"babel-generator": "6.26.1",
+				"babel-helpers": "6.24.1",
+				"babel-messages": "6.23.0",
+				"babel-register": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"convert-source-map": "1.5.1",
+				"debug": "2.6.9",
+				"json5": "0.5.1",
+				"lodash": "4.17.5",
+				"minimatch": "3.0.4",
+				"path-is-absolute": "1.0.1",
+				"private": "0.1.8",
+				"slash": "1.0.0",
+				"source-map": "0.5.7"
+			}
+		},
+		"babel-generator": {
+			"version": "6.26.1",
+			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+			"dev": true,
+			"requires": {
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"detect-indent": "4.0.0",
+				"jsesc": "1.3.0",
+				"lodash": "4.17.5",
+				"source-map": "0.5.7",
+				"trim-right": "1.0.1"
+			}
+		},
+		"babel-helpers": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
+			}
+		},
+		"babel-jest": {
+			"version": "22.4.1",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.4.1.tgz",
+			"integrity": "sha512-rEdN/jevSuX0IQKcUqwqOGa0gDNis4jGY52Rq53aizfDGPwQYNJq+f9NCMT1HUhtUZhYSjvfGUfHQWBRT1/icA==",
+			"dev": true,
+			"requires": {
+				"babel-plugin-istanbul": "4.1.5",
+				"babel-preset-jest": "22.4.1"
+			}
+		},
+		"babel-messages": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-istanbul": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz",
+			"integrity": "sha1-Z2DN2Xf0EdPhdbsGTyvDJ9mbK24=",
+			"dev": true,
+			"requires": {
+				"find-up": "2.1.0",
+				"istanbul-lib-instrument": "1.9.2",
+				"test-exclude": "4.2.0"
+			}
+		},
+		"babel-plugin-jest-hoist": {
+			"version": "22.4.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.1.tgz",
+			"integrity": "sha512-gmj5FvFflXSnRapWmF/jDjx5Lof1kX0OwXibCxMOx38V3CFMOnTxLTUrAFfLkhCey3FJvv0ACvv/+h4nzFRxhg==",
+			"dev": true
+		},
+		"babel-plugin-syntax-object-rest-spread": {
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+			"dev": true
+		},
+		"babel-preset-jest": {
+			"version": "22.4.1",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.1.tgz",
+			"integrity": "sha512-gW3+spyB8fkSAI9fX+41BQMwar5LjR+nyKa2QRvK22snxnI29+jJVAMfId+osucFJzJJvhlvzKWnfwX8Omodvg==",
+			"dev": true,
+			"requires": {
+				"babel-plugin-jest-hoist": "22.4.1",
+				"babel-plugin-syntax-object-rest-spread": "6.13.0"
+			}
+		},
+		"babel-register": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+			"dev": true,
+			"requires": {
+				"babel-core": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"core-js": "2.5.3",
+				"home-or-tmp": "2.0.0",
+				"lodash": "4.17.5",
+				"mkdirp": "0.5.1",
+				"source-map-support": "0.4.18"
+			},
+			"dependencies": {
+				"source-map-support": {
+					"version": "0.4.18",
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+					"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+					"dev": true,
+					"requires": {
+						"source-map": "0.5.7"
+					}
+				}
+			}
+		},
+		"babel-runtime": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+			"dev": true,
+			"requires": {
+				"core-js": "2.5.3",
+				"regenerator-runtime": "0.11.1"
+			}
+		},
+		"babel-template": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"lodash": "4.17.5"
+			}
+		},
+		"babel-traverse": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+			"dev": true,
+			"requires": {
+				"babel-code-frame": "6.26.0",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"debug": "2.6.9",
+				"globals": "9.18.0",
+				"invariant": "2.2.3",
+				"lodash": "4.17.5"
+			}
+		},
+		"babel-types": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"esutils": "2.0.2",
+				"lodash": "4.17.5",
+				"to-fast-properties": "1.0.3"
+			}
+		},
+		"babylon": {
+			"version": "6.18.0",
+			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+			"dev": true
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
+		},
+		"bcrypt-pbkdf": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"tweetnacl": "0.14.5"
+			}
+		},
+		"boom": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+			"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+			"dev": true,
+			"requires": {
+				"hoek": "4.2.1"
+			}
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"requires": {
+				"balanced-match": "1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"braces": {
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+			"dev": true,
+			"requires": {
+				"expand-range": "1.8.2",
+				"preserve": "0.2.0",
+				"repeat-element": "1.1.2"
+			}
+		},
+		"browser-process-hrtime": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
+			"integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44=",
+			"dev": true
+		},
+		"browser-resolve": {
+			"version": "1.11.2",
+			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
+			"integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
+			"dev": true,
+			"requires": {
+				"resolve": "1.1.7"
+			}
+		},
+		"bser": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
+			"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+			"dev": true,
+			"requires": {
+				"node-int64": "0.4.0"
+			}
+		},
+		"builtin-modules": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+			"dev": true
+		},
+		"callsites": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+			"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+			"dev": true
+		},
+		"camelcase": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+			"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+			"dev": true,
+			"optional": true
+		},
+		"caseless": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+			"dev": true
+		},
+		"center-align": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"align-text": "0.1.4",
+				"lazy-cache": "1.0.4"
+			}
+		},
+		"chalk": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+			"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "3.2.0",
+				"escape-string-regexp": "1.0.5",
+				"supports-color": "5.2.0"
+			}
+		},
+		"ci-info": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
+			"integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==",
+			"dev": true
+		},
+		"cliui": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+			"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"center-align": "0.1.3",
+				"right-align": "0.1.3",
+				"wordwrap": "0.0.2"
+			},
+			"dependencies": {
+				"wordwrap": {
+					"version": "0.0.2",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+					"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+					"dev": true,
+					"optional": true
+				}
+			}
+		},
+		"co": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"dev": true
+		},
+		"code-point-at": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+			"dev": true
+		},
+		"color-convert": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+			"dev": true,
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
+		},
+		"combined-stream": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+			"dev": true,
+			"requires": {
+				"delayed-stream": "1.0.0"
+			}
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
+		},
+		"content-type-parser": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
+			"integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ==",
+			"dev": true
+		},
+		"convert-source-map": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+			"dev": true
+		},
+		"core-js": {
+			"version": "2.5.3",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+			"integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
+			"dev": true
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
+		},
+		"cross-spawn": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+			"dev": true,
+			"requires": {
+				"lru-cache": "4.1.1",
+				"shebang-command": "1.2.0",
+				"which": "1.3.0"
+			}
+		},
+		"cryptiles": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+			"integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+			"dev": true,
+			"requires": {
+				"boom": "5.2.0"
+			},
+			"dependencies": {
+				"boom": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+					"integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+					"dev": true,
+					"requires": {
+						"hoek": "4.2.1"
+					}
+				}
+			}
+		},
+		"cssom": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
+			"integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs=",
+			"dev": true
+		},
+		"cssstyle": {
+			"version": "0.2.37",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
+			"integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+			"dev": true,
+			"requires": {
+				"cssom": "0.3.2"
+			}
+		},
+		"dashdash": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "1.0.0"
+			}
+		},
+		"debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"requires": {
+				"ms": "2.0.0"
+			}
+		},
+		"decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+			"dev": true
+		},
+		"deep-is": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"dev": true
+		},
+		"default-require-extensions": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
+			"integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+			"dev": true,
+			"requires": {
+				"strip-bom": "2.0.0"
+			}
+		},
+		"define-properties": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+			"dev": true,
+			"requires": {
+				"foreach": "2.0.5",
+				"object-keys": "1.0.11"
+			}
+		},
+		"delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+			"dev": true
+		},
+		"detect-indent": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+			"dev": true,
+			"requires": {
+				"repeating": "2.0.1"
+			}
+		},
+		"detect-newline": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+			"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+			"dev": true
+		},
+		"diff": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
+			"integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
+			"dev": true
+		},
+		"domexception": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+			"dev": true,
+			"requires": {
+				"webidl-conversions": "4.0.2"
+			}
+		},
+		"ecc-jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"jsbn": "0.1.1"
+			}
+		},
+		"error-ex": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+			"dev": true,
+			"requires": {
+				"is-arrayish": "0.2.1"
+			}
+		},
+		"es-abstract": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
+			"integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
+			"dev": true,
+			"requires": {
+				"es-to-primitive": "1.1.1",
+				"function-bind": "1.1.1",
+				"has": "1.0.1",
+				"is-callable": "1.1.3",
+				"is-regex": "1.0.4"
+			}
+		},
+		"es-to-primitive": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+			"dev": true,
+			"requires": {
+				"is-callable": "1.1.3",
+				"is-date-object": "1.0.1",
+				"is-symbol": "1.0.1"
+			}
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
+		},
+		"escodegen": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
+			"integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
+			"dev": true,
+			"requires": {
+				"esprima": "3.1.3",
+				"estraverse": "4.2.0",
+				"esutils": "2.0.2",
+				"optionator": "0.8.2",
+				"source-map": "0.6.1"
+			},
+			"dependencies": {
+				"esprima": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true,
+					"optional": true
+				}
+			}
+		},
+		"esprima": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+			"dev": true
+		},
+		"estraverse": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+			"dev": true
+		},
+		"esutils": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"dev": true
+		},
+		"exec-sh": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
+			"integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
+			"dev": true,
+			"requires": {
+				"merge": "1.2.0"
+			}
+		},
+		"execa": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+			"dev": true,
+			"requires": {
+				"cross-spawn": "5.1.0",
+				"get-stream": "3.0.0",
+				"is-stream": "1.1.0",
+				"npm-run-path": "2.0.2",
+				"p-finally": "1.0.0",
+				"signal-exit": "3.0.2",
+				"strip-eof": "1.0.0"
+			}
+		},
+		"exit": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+			"integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+			"dev": true
+		},
+		"expand-brackets": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"dev": true,
+			"requires": {
+				"is-posix-bracket": "0.1.1"
+			}
+		},
+		"expand-range": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+			"dev": true,
+			"requires": {
+				"fill-range": "2.2.3"
+			}
+		},
+		"expect": {
+			"version": "22.4.0",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-22.4.0.tgz",
+			"integrity": "sha512-Fiy862jT3qc70hwIHwwCBNISmaqBrfWKKrtqyMJ6iwZr+6KXtcnHojZFtd63TPRvRl8EQTJ+YXYy2lK6/6u+Hw==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "3.2.0",
+				"jest-diff": "22.4.0",
+				"jest-get-type": "22.1.0",
+				"jest-matcher-utils": "22.4.0",
+				"jest-message-util": "22.4.0",
+				"jest-regex-util": "22.1.0"
+			}
+		},
+		"extend": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+			"dev": true
+		},
+		"extglob": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+			"dev": true,
+			"requires": {
+				"is-extglob": "1.0.0"
+			}
+		},
+		"extsprintf": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"dev": true
+		},
+		"fast-deep-equal": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+			"dev": true
+		},
+		"fast-json-stable-stringify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+			"dev": true
+		},
+		"fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"dev": true
+		},
+		"fb-watchman": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
+			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+			"dev": true,
+			"requires": {
+				"bser": "2.0.0"
+			}
+		},
+		"filename-regex": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+			"dev": true
+		},
+		"fileset": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
+			"integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
+			"dev": true,
+			"requires": {
+				"glob": "7.1.2",
+				"minimatch": "3.0.4"
+			}
+		},
+		"fill-range": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+			"dev": true,
+			"requires": {
+				"is-number": "2.1.0",
+				"isobject": "2.1.0",
+				"randomatic": "1.1.7",
+				"repeat-element": "1.1.2",
+				"repeat-string": "1.6.1"
+			}
+		},
+		"find-up": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+			"dev": true,
+			"requires": {
+				"locate-path": "2.0.0"
+			}
+		},
+		"for-in": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+			"dev": true
+		},
+		"for-own": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"dev": true,
+			"requires": {
+				"for-in": "1.0.2"
+			}
+		},
+		"foreach": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+			"dev": true
+		},
+		"forever-agent": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+			"dev": true
+		},
+		"form-data": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+			"dev": true,
+			"requires": {
+				"asynckit": "0.4.0",
+				"combined-stream": "1.0.6",
+				"mime-types": "2.1.18"
+			}
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
+		},
+		"fsevents": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+			"integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"nan": "2.9.2",
+				"node-pre-gyp": "0.6.39"
+			},
+			"dependencies": {
+				"abbrev": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"ajv": {
+					"version": "4.11.8",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"co": "4.6.0",
+						"json-stable-stringify": "1.0.1"
+					}
+				},
+				"ansi-regex": {
+					"version": "2.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"aproba": {
+					"version": "1.1.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"are-we-there-yet": {
+					"version": "1.1.4",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"delegates": "1.0.0",
+						"readable-stream": "2.2.9"
+					}
+				},
+				"asn1": {
+					"version": "0.2.3",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"assert-plus": {
+					"version": "0.2.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"asynckit": {
+					"version": "0.4.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"aws-sign2": {
+					"version": "0.6.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"aws4": {
+					"version": "1.6.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"balanced-match": {
+					"version": "0.4.2",
+					"bundled": true,
+					"dev": true
+				},
+				"bcrypt-pbkdf": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"tweetnacl": "0.14.5"
+					}
+				},
+				"block-stream": {
+					"version": "0.0.9",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"inherits": "2.0.3"
+					}
+				},
+				"boom": {
+					"version": "2.10.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"hoek": "2.16.3"
+					}
+				},
+				"brace-expansion": {
+					"version": "1.1.7",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"balanced-match": "0.4.2",
+						"concat-map": "0.0.1"
+					}
+				},
+				"buffer-shims": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"caseless": {
+					"version": "0.12.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"co": {
+					"version": "4.6.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"code-point-at": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"combined-stream": {
+					"version": "1.0.5",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"delayed-stream": "1.0.0"
+					}
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"console-control-strings": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"core-util-is": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"cryptiles": {
+					"version": "2.0.5",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"boom": "2.10.1"
+					}
+				},
+				"dashdash": {
+					"version": "1.14.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "1.0.0"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						}
+					}
+				},
+				"debug": {
+					"version": "2.6.8",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"deep-extend": {
+					"version": "0.4.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"delayed-stream": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"delegates": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"detect-libc": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"ecc-jsbn": {
+					"version": "0.1.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"jsbn": "0.1.1"
+					}
+				},
+				"extend": {
+					"version": "3.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"extsprintf": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"forever-agent": {
+					"version": "0.6.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"form-data": {
+					"version": "2.1.4",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"asynckit": "0.4.0",
+						"combined-stream": "1.0.5",
+						"mime-types": "2.1.15"
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"fstream": {
+					"version": "1.0.11",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"inherits": "2.0.3",
+						"mkdirp": "0.5.1",
+						"rimraf": "2.6.1"
+					}
+				},
+				"fstream-ignore": {
+					"version": "1.0.5",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"fstream": "1.0.11",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4"
+					}
+				},
+				"gauge": {
+					"version": "2.7.4",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"aproba": "1.1.1",
+						"console-control-strings": "1.1.0",
+						"has-unicode": "2.0.1",
+						"object-assign": "4.1.1",
+						"signal-exit": "3.0.2",
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wide-align": "1.1.2"
+					}
+				},
+				"getpass": {
+					"version": "0.1.7",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "1.0.0"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						}
+					}
+				},
+				"glob": {
+					"version": "7.1.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.1.11",
+					"bundled": true,
+					"dev": true
+				},
+				"har-schema": {
+					"version": "1.0.5",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"har-validator": {
+					"version": "4.2.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"ajv": "4.11.8",
+						"har-schema": "1.0.5"
+					}
+				},
+				"has-unicode": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"hawk": {
+					"version": "3.1.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"boom": "2.10.1",
+						"cryptiles": "2.0.5",
+						"hoek": "2.16.3",
+						"sntp": "1.0.9"
+					}
+				},
+				"hoek": {
+					"version": "2.16.3",
+					"bundled": true,
+					"dev": true
+				},
+				"http-signature": {
+					"version": "1.1.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "0.2.0",
+						"jsprim": "1.4.0",
+						"sshpk": "1.13.0"
+					}
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"once": "1.4.0",
+						"wrappy": "1.0.2"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"bundled": true,
+					"dev": true
+				},
+				"ini": {
+					"version": "1.3.4",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"is-typedarray": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"isstream": {
+					"version": "0.1.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"jodid25519": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"jsbn": "0.1.1"
+					}
+				},
+				"jsbn": {
+					"version": "0.1.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"json-schema": {
+					"version": "0.2.3",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"json-stable-stringify": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"jsonify": "0.0.0"
+					}
+				},
+				"json-stringify-safe": {
+					"version": "5.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"jsonify": {
+					"version": "0.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"jsprim": {
+					"version": "1.4.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "1.0.0",
+						"extsprintf": "1.0.2",
+						"json-schema": "0.2.3",
+						"verror": "1.3.6"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						}
+					}
+				},
+				"mime-db": {
+					"version": "1.27.0",
+					"bundled": true,
+					"dev": true
+				},
+				"mime-types": {
+					"version": "2.1.15",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"mime-db": "1.27.0"
+					}
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"brace-expansion": "1.1.7"
+					}
+				},
+				"minimist": {
+					"version": "0.0.8",
+					"bundled": true,
+					"dev": true
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"minimist": "0.0.8"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"node-pre-gyp": {
+					"version": "0.6.39",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"detect-libc": "1.0.2",
+						"hawk": "3.1.3",
+						"mkdirp": "0.5.1",
+						"nopt": "4.0.1",
+						"npmlog": "4.1.0",
+						"rc": "1.2.1",
+						"request": "2.81.0",
+						"rimraf": "2.6.1",
+						"semver": "5.3.0",
+						"tar": "2.2.1",
+						"tar-pack": "3.4.0"
+					}
+				},
+				"nopt": {
+					"version": "4.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"abbrev": "1.1.0",
+						"osenv": "0.1.4"
+					}
+				},
+				"npmlog": {
+					"version": "4.1.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"are-we-there-yet": "1.1.4",
+						"console-control-strings": "1.1.0",
+						"gauge": "2.7.4",
+						"set-blocking": "2.0.0"
+					}
+				},
+				"number-is-nan": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"oauth-sign": {
+					"version": "0.8.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"once": {
+					"version": "1.4.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"wrappy": "1.0.2"
+					}
+				},
+				"os-homedir": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"os-tmpdir": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"osenv": {
+					"version": "0.1.4",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"os-homedir": "1.0.2",
+						"os-tmpdir": "1.0.2"
+					}
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"performance-now": {
+					"version": "0.2.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"process-nextick-args": {
+					"version": "1.0.7",
+					"bundled": true,
+					"dev": true
+				},
+				"punycode": {
+					"version": "1.4.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"qs": {
+					"version": "6.4.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"rc": {
+					"version": "1.2.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"deep-extend": "0.4.2",
+						"ini": "1.3.4",
+						"minimist": "1.2.0",
+						"strip-json-comments": "2.0.1"
+					},
+					"dependencies": {
+						"minimist": {
+							"version": "1.2.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						}
+					}
+				},
+				"readable-stream": {
+					"version": "2.2.9",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"buffer-shims": "1.0.0",
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "1.0.7",
+						"string_decoder": "1.0.1",
+						"util-deprecate": "1.0.2"
+					}
+				},
+				"request": {
+					"version": "2.81.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"aws-sign2": "0.6.0",
+						"aws4": "1.6.0",
+						"caseless": "0.12.0",
+						"combined-stream": "1.0.5",
+						"extend": "3.0.1",
+						"forever-agent": "0.6.1",
+						"form-data": "2.1.4",
+						"har-validator": "4.2.1",
+						"hawk": "3.1.3",
+						"http-signature": "1.1.1",
+						"is-typedarray": "1.0.0",
+						"isstream": "0.1.2",
+						"json-stringify-safe": "5.0.1",
+						"mime-types": "2.1.15",
+						"oauth-sign": "0.8.2",
+						"performance-now": "0.2.0",
+						"qs": "6.4.0",
+						"safe-buffer": "5.0.1",
+						"stringstream": "0.0.5",
+						"tough-cookie": "2.3.2",
+						"tunnel-agent": "0.6.0",
+						"uuid": "3.0.1"
+					}
+				},
+				"rimraf": {
+					"version": "2.6.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"glob": "7.1.2"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"semver": {
+					"version": "5.3.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"signal-exit": {
+					"version": "3.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"sntp": {
+					"version": "1.0.9",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"hoek": "2.16.3"
+					}
+				},
+				"sshpk": {
+					"version": "1.13.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"asn1": "0.2.3",
+						"assert-plus": "1.0.0",
+						"bcrypt-pbkdf": "1.0.1",
+						"dashdash": "1.14.1",
+						"ecc-jsbn": "0.1.1",
+						"getpass": "0.1.7",
+						"jodid25519": "1.0.2",
+						"jsbn": "0.1.1",
+						"tweetnacl": "0.14.5"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						}
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				},
+				"string_decoder": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"safe-buffer": "5.0.1"
+					}
+				},
+				"stringstream": {
+					"version": "0.0.5",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"strip-json-comments": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"tar": {
+					"version": "2.2.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"block-stream": "0.0.9",
+						"fstream": "1.0.11",
+						"inherits": "2.0.3"
+					}
+				},
+				"tar-pack": {
+					"version": "3.4.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"debug": "2.6.8",
+						"fstream": "1.0.11",
+						"fstream-ignore": "1.0.5",
+						"once": "1.4.0",
+						"readable-stream": "2.2.9",
+						"rimraf": "2.6.1",
+						"tar": "2.2.1",
+						"uid-number": "0.0.6"
+					}
+				},
+				"tough-cookie": {
+					"version": "2.3.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"punycode": "1.4.1"
+					}
+				},
+				"tunnel-agent": {
+					"version": "0.6.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"safe-buffer": "5.0.1"
+					}
+				},
+				"tweetnacl": {
+					"version": "0.14.5",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"uid-number": {
+					"version": "0.0.6",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"util-deprecate": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"uuid": {
+					"version": "3.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"verror": {
+					"version": "1.3.6",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"extsprintf": "1.0.2"
+					}
+				},
+				"wide-align": {
+					"version": "1.1.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"string-width": "1.0.2"
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				}
+			}
+		},
+		"function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
+		},
+		"get-caller-file": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+			"dev": true
+		},
+		"get-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+			"dev": true
+		},
+		"getpass": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "1.0.0"
+			}
+		},
+		"glob": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"dev": true,
+			"requires": {
+				"fs.realpath": "1.0.0",
+				"inflight": "1.0.6",
+				"inherits": "2.0.3",
+				"minimatch": "3.0.4",
+				"once": "1.4.0",
+				"path-is-absolute": "1.0.1"
+			}
+		},
+		"glob-base": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+			"dev": true,
+			"requires": {
+				"glob-parent": "2.0.0",
+				"is-glob": "2.0.1"
+			}
+		},
+		"glob-parent": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+			"dev": true,
+			"requires": {
+				"is-glob": "2.0.1"
+			}
+		},
+		"globals": {
+			"version": "9.18.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+			"dev": true
+		},
+		"graceful-fs": {
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+			"dev": true
+		},
+		"growly": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+			"dev": true
+		},
+		"handlebars": {
+			"version": "4.0.11",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+			"integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+			"dev": true,
+			"requires": {
+				"async": "1.5.2",
+				"optimist": "0.6.1",
+				"source-map": "0.4.4",
+				"uglify-js": "2.8.29"
+			},
+			"dependencies": {
+				"async": {
+					"version": "1.5.2",
+					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.4.4",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+					"dev": true,
+					"requires": {
+						"amdefine": "1.0.1"
+					}
+				}
+			}
+		},
+		"har-schema": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+			"dev": true
+		},
+		"har-validator": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+			"dev": true,
+			"requires": {
+				"ajv": "5.5.2",
+				"har-schema": "2.0.0"
+			}
+		},
+		"has": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+			"dev": true,
+			"requires": {
+				"function-bind": "1.1.1"
+			}
+		},
+		"has-ansi": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "2.1.1"
+			}
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
+		},
+		"hawk": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+			"integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+			"dev": true,
+			"requires": {
+				"boom": "4.3.1",
+				"cryptiles": "3.1.2",
+				"hoek": "4.2.1",
+				"sntp": "2.1.0"
+			}
+		},
+		"hoek": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+			"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
+			"dev": true
+		},
+		"home-or-tmp": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+			"dev": true,
+			"requires": {
+				"os-homedir": "1.0.2",
+				"os-tmpdir": "1.0.2"
+			}
+		},
+		"hosted-git-info": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+			"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+			"dev": true
+		},
+		"html-encoding-sniffer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+			"dev": true,
+			"requires": {
+				"whatwg-encoding": "1.0.3"
+			}
+		},
+		"http-signature": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "1.0.0",
+				"jsprim": "1.4.1",
+				"sshpk": "1.13.1"
+			}
+		},
+		"iconv-lite": {
+			"version": "0.4.19",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+			"dev": true
+		},
+		"import-local": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
+			"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+			"dev": true,
+			"requires": {
+				"pkg-dir": "2.0.0",
+				"resolve-cwd": "2.0.0"
+			}
+		},
+		"imurmurhash": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
+			"requires": {
+				"once": "1.4.0",
+				"wrappy": "1.0.2"
+			}
+		},
+		"inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"dev": true
+		},
+		"invariant": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.3.tgz",
+			"integrity": "sha512-7Z5PPegwDTyjbaeCnV0efcyS6vdKAU51kpEmS7QFib3P4822l8ICYyMn7qvJnc+WzLoDsuI9gPMKbJ8pCu8XtA==",
+			"dev": true,
+			"requires": {
+				"loose-envify": "1.3.1"
+			}
+		},
+		"invert-kv": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+			"dev": true
+		},
+		"is-arrayish": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+			"dev": true
+		},
+		"is-buffer": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+			"dev": true
+		},
+		"is-builtin-module": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+			"dev": true,
+			"requires": {
+				"builtin-modules": "1.1.1"
+			}
+		},
+		"is-callable": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+			"dev": true
+		},
+		"is-ci": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
+			"integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+			"dev": true,
+			"requires": {
+				"ci-info": "1.1.2"
+			}
+		},
+		"is-date-object": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+			"dev": true
+		},
+		"is-dotfile": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+			"dev": true
+		},
+		"is-equal-shallow": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+			"dev": true,
+			"requires": {
+				"is-primitive": "2.0.0"
+			}
+		},
+		"is-extendable": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"dev": true
+		},
+		"is-extglob": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+			"dev": true
+		},
+		"is-finite": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+			"dev": true,
+			"requires": {
+				"number-is-nan": "1.0.1"
+			}
+		},
+		"is-fullwidth-code-point": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+			"dev": true
+		},
+		"is-generator-fn": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
+			"integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go=",
+			"dev": true
+		},
+		"is-glob": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+			"dev": true,
+			"requires": {
+				"is-extglob": "1.0.0"
+			}
+		},
+		"is-number": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+			"dev": true,
+			"requires": {
+				"kind-of": "3.2.2"
+			}
+		},
+		"is-posix-bracket": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+			"dev": true
+		},
+		"is-primitive": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+			"dev": true
+		},
+		"is-regex": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+			"dev": true,
+			"requires": {
+				"has": "1.0.1"
+			}
+		},
+		"is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+			"dev": true
+		},
+		"is-symbol": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+			"dev": true
+		},
+		"is-typedarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"dev": true
+		},
+		"is-utf8": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+			"dev": true
+		},
+		"isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
+		},
+		"isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
+		},
+		"isobject": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+			"dev": true,
+			"requires": {
+				"isarray": "1.0.0"
+			}
+		},
+		"isstream": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+			"dev": true
+		},
+		"istanbul-api": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.2.2.tgz",
+			"integrity": "sha512-kH5YRdqdbs5hiH4/Rr1Q0cSAGgjh3jTtg8vu9NLebBAoK3adVO4jk81J+TYOkTr2+Q4NLeb1ACvmEt65iG/Vbw==",
+			"dev": true,
+			"requires": {
+				"async": "2.6.0",
+				"fileset": "2.0.3",
+				"istanbul-lib-coverage": "1.1.2",
+				"istanbul-lib-hook": "1.1.0",
+				"istanbul-lib-instrument": "1.9.2",
+				"istanbul-lib-report": "1.1.3",
+				"istanbul-lib-source-maps": "1.2.3",
+				"istanbul-reports": "1.1.4",
+				"js-yaml": "3.10.0",
+				"mkdirp": "0.5.1",
+				"once": "1.4.0"
+			}
+		},
+		"istanbul-lib-coverage": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.2.tgz",
+			"integrity": "sha512-tZYA0v5A7qBSsOzcebJJ/z3lk3oSzH62puG78DbBA1+zupipX2CakDyiPV3pOb8He+jBwVimuwB0dTnh38hX0w==",
+			"dev": true
+		},
+		"istanbul-lib-hook": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz",
+			"integrity": "sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==",
+			"dev": true,
+			"requires": {
+				"append-transform": "0.4.0"
+			}
+		},
+		"istanbul-lib-instrument": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.2.tgz",
+			"integrity": "sha512-nz8t4HQ2206a/3AXi+NHFWEa844DMpPsgbcUteJbt1j8LX1xg56H9rOMnhvcvVvPbW60qAIyrSk44H8ZDqaSSA==",
+			"dev": true,
+			"requires": {
+				"babel-generator": "6.26.1",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"istanbul-lib-coverage": "1.1.2",
+				"semver": "5.5.0"
+			}
+		},
+		"istanbul-lib-report": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.3.tgz",
+			"integrity": "sha512-D4jVbMDtT2dPmloPJS/rmeP626N5Pr3Rp+SovrPn1+zPChGHcggd/0sL29jnbm4oK9W0wHjCRsdch9oLd7cm6g==",
+			"dev": true,
+			"requires": {
+				"istanbul-lib-coverage": "1.1.2",
+				"mkdirp": "0.5.1",
+				"path-parse": "1.0.5",
+				"supports-color": "3.2.3"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
+			}
+		},
+		"istanbul-lib-source-maps": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz",
+			"integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
+			"dev": true,
+			"requires": {
+				"debug": "3.1.0",
+				"istanbul-lib-coverage": "1.1.2",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.2",
+				"source-map": "0.5.7"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				}
+			}
+		},
+		"istanbul-reports": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.4.tgz",
+			"integrity": "sha512-DfSTVOTkuO+kRmbO8Gk650Wqm1WRGr6lrdi2EwDK1vxpS71vdlLd613EpzOKdIFioB5f/scJTjeWBnvd1FWejg==",
+			"dev": true,
+			"requires": {
+				"handlebars": "4.0.11"
+			}
+		},
+		"jest": {
+			"version": "22.4.2",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-22.4.2.tgz",
+			"integrity": "sha512-wD7dXWtfaQAgbNVsjFqzmuhg6nzwGsTRVea3FpSJ7GURhG+J536fw4mdoLB01DgiEozDDeF1ZMR/UlUszTsCrg==",
+			"dev": true,
+			"requires": {
+				"import-local": "1.0.0",
+				"jest-cli": "22.4.2"
+			},
+			"dependencies": {
+				"jest-cli": {
+					"version": "22.4.2",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-22.4.2.tgz",
+					"integrity": "sha512-ebo6ZWK2xDSs7LGnLvM16SZOIJ2dj0B6/oERmGcal32NHkks450nNfGrGTyOSPgJDgH8DFhVdBXgSamN7mtZ0Q==",
+					"dev": true,
+					"requires": {
+						"ansi-escapes": "3.0.0",
+						"chalk": "2.3.1",
+						"exit": "0.1.2",
+						"glob": "7.1.2",
+						"graceful-fs": "4.1.11",
+						"import-local": "1.0.0",
+						"is-ci": "1.1.0",
+						"istanbul-api": "1.2.2",
+						"istanbul-lib-coverage": "1.1.2",
+						"istanbul-lib-instrument": "1.9.2",
+						"istanbul-lib-source-maps": "1.2.3",
+						"jest-changed-files": "22.2.0",
+						"jest-config": "22.4.2",
+						"jest-environment-jsdom": "22.4.1",
+						"jest-get-type": "22.1.0",
+						"jest-haste-map": "22.4.2",
+						"jest-message-util": "22.4.0",
+						"jest-regex-util": "22.1.0",
+						"jest-resolve-dependencies": "22.1.0",
+						"jest-runner": "22.4.2",
+						"jest-runtime": "22.4.2",
+						"jest-snapshot": "22.4.0",
+						"jest-util": "22.4.1",
+						"jest-validate": "22.4.2",
+						"jest-worker": "22.2.2",
+						"micromatch": "2.3.11",
+						"node-notifier": "5.2.1",
+						"realpath-native": "1.0.0",
+						"rimraf": "2.6.2",
+						"slash": "1.0.0",
+						"string-length": "2.0.0",
+						"strip-ansi": "4.0.0",
+						"which": "1.3.0",
+						"yargs": "10.1.2"
+					}
+				}
+			}
+		},
+		"jest-changed-files": {
+			"version": "22.2.0",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-22.2.0.tgz",
+			"integrity": "sha512-SzqOvoPMrXB0NPvDrSPeKETpoUNCtNDOsFbCzAGWxqWVvNyrIMLpUjVExT3u3LfdVrENlrNGCfh5YoFd8+ZeXg==",
+			"dev": true,
+			"requires": {
+				"throat": "4.1.0"
+			}
+		},
+		"jest-config": {
+			"version": "22.4.2",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.4.2.tgz",
+			"integrity": "sha512-oG31qYO73/3vj/Q8aM2RgzmHndTkz9nRk8ISybfuJqqbf0RW7OUjHVOZPLOUiwLWtz52Yq2HkjIblsyhbA7vrg==",
+			"dev": true,
+			"requires": {
+				"chalk": "2.3.1",
+				"glob": "7.1.2",
+				"jest-environment-jsdom": "22.4.1",
+				"jest-environment-node": "22.4.1",
+				"jest-get-type": "22.1.0",
+				"jest-jasmine2": "22.4.2",
+				"jest-regex-util": "22.1.0",
+				"jest-resolve": "22.4.2",
+				"jest-util": "22.4.1",
+				"jest-validate": "22.4.2",
+				"pretty-format": "22.4.0"
+			}
+		},
+		"jest-diff": {
+			"version": "22.4.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.0.tgz",
+			"integrity": "sha512-+/t20WmnkOkB8MOaGaPziI8zWKxquMvYw4Ub+wOzi7AUhmpFXz43buWSxVoZo4J5RnCozpGbX3/FssjJ5KV9Nw==",
+			"dev": true,
+			"requires": {
+				"chalk": "2.3.1",
+				"diff": "3.4.0",
+				"jest-get-type": "22.1.0",
+				"pretty-format": "22.4.0"
+			}
+		},
+		"jest-docblock": {
+			"version": "22.4.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.4.0.tgz",
+			"integrity": "sha512-lDY7GZ+/CJb02oULYLBDj7Hs5shBhVpDYpIm8LUyqw9X2J22QRsM19gmGQwIFqGSJmpc/LRrSYudeSrG510xlQ==",
+			"dev": true,
+			"requires": {
+				"detect-newline": "2.1.0"
+			}
+		},
+		"jest-environment-jsdom": {
+			"version": "22.4.1",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.1.tgz",
+			"integrity": "sha512-x/JzAoH+dWPBnIMv5OQKiIR0TYf6UvbRjsIuDZ11yDFXkHKGJZg6jNnLAsokAm3cq9kUa2hH5BPUC9XU4n1ELQ==",
+			"dev": true,
+			"requires": {
+				"jest-mock": "22.2.0",
+				"jest-util": "22.4.1",
+				"jsdom": "11.6.2"
+			}
+		},
+		"jest-environment-node": {
+			"version": "22.4.1",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.4.1.tgz",
+			"integrity": "sha512-wj9+zzfRgnUbm5VwFOCGgG1QmbucUyrjPKBKUJdLW8K5Ss5zrNc1k+v6feZhFg6sS3ZGnjgtIyklaxEARxu+LQ==",
+			"dev": true,
+			"requires": {
+				"jest-mock": "22.2.0",
+				"jest-util": "22.4.1"
+			}
+		},
+		"jest-get-type": {
+			"version": "22.1.0",
+			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.1.0.tgz",
+			"integrity": "sha512-nD97IVOlNP6fjIN5i7j5XRH+hFsHL7VlauBbzRvueaaUe70uohrkz7pL/N8lx/IAwZRTJ//wOdVgh85OgM7g3w==",
+			"dev": true
+		},
+		"jest-haste-map": {
+			"version": "22.4.2",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.4.2.tgz",
+			"integrity": "sha512-EdQADHGXRqHJYAr7q9B9YYHZnrlcMwhx1+DnIgc9uN05nCW3RvGCxJ91MqWXcC1AzatLoSv7SNd0qXMp2jKBDA==",
+			"dev": true,
+			"requires": {
+				"fb-watchman": "2.0.0",
+				"graceful-fs": "4.1.11",
+				"jest-docblock": "22.4.0",
+				"jest-serializer": "22.4.0",
+				"jest-worker": "22.2.2",
+				"micromatch": "2.3.11",
+				"sane": "2.4.1"
+			}
+		},
+		"jest-jasmine2": {
+			"version": "22.4.2",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.4.2.tgz",
+			"integrity": "sha512-KZaIHpXQ0AIlvQJFCU0uoXxtz5GG47X14r9upMe7VXE55UazoMZBFnQb9TX2HoYX2/AxJYnjHuvwKVCFqOrEtw==",
+			"dev": true,
+			"requires": {
+				"chalk": "2.3.1",
+				"co": "4.6.0",
+				"expect": "22.4.0",
+				"graceful-fs": "4.1.11",
+				"is-generator-fn": "1.0.0",
+				"jest-diff": "22.4.0",
+				"jest-matcher-utils": "22.4.0",
+				"jest-message-util": "22.4.0",
+				"jest-snapshot": "22.4.0",
+				"jest-util": "22.4.1",
+				"source-map-support": "0.5.3"
+			}
+		},
+		"jest-leak-detector": {
+			"version": "22.4.0",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.4.0.tgz",
+			"integrity": "sha512-r3NEIVNh4X3fEeJtUIrKXWKhNokwUM2ILp5LD8w1KrEanPsFtZmYjmyZYjDTX2dXYr33TW65OvbRE3hWFAyq6g==",
+			"dev": true,
+			"requires": {
+				"pretty-format": "22.4.0"
+			}
+		},
+		"jest-matcher-utils": {
+			"version": "22.4.0",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.0.tgz",
+			"integrity": "sha512-03m3issxUXpWMwDYTfmL8hRNewUB0yCRTeXPm+eq058rZxLHD9f5NtSSO98CWHqe4UyISIxd9Ao9iDVjHWd2qg==",
+			"dev": true,
+			"requires": {
+				"chalk": "2.3.1",
+				"jest-get-type": "22.1.0",
+				"pretty-format": "22.4.0"
+			}
+		},
+		"jest-message-util": {
+			"version": "22.4.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.0.tgz",
+			"integrity": "sha512-eyCJB0T3hrlpFF2FqQoIB093OulP+1qvATQmD3IOgJgMGqPL6eYw8TbC5P/VCWPqKhGL51xvjIIhow5eZ2wHFw==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "7.0.0-beta.40",
+				"chalk": "2.3.1",
+				"micromatch": "2.3.11",
+				"slash": "1.0.0",
+				"stack-utils": "1.0.1"
+			}
+		},
+		"jest-mock": {
+			"version": "22.2.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-22.2.0.tgz",
+			"integrity": "sha512-eOfoUYLOB/JlxChOFkh/bzpWGqUXb9I+oOpkprHHs9L7nUNfL8Rk28h1ycWrqzWCEQ/jZBg/xIv7VdQkfAkOhw==",
+			"dev": true
+		},
+		"jest-regex-util": {
+			"version": "22.1.0",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-22.1.0.tgz",
+			"integrity": "sha512-on0LqVS6Xeh69sw3d1RukVnur+lVOl3zkmb0Q54FHj9wHoq6dbtWqb3TSlnVUyx36hqjJhjgs/QLqs07Bzu72Q==",
+			"dev": true
+		},
+		"jest-resolve": {
+			"version": "22.4.2",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.4.2.tgz",
+			"integrity": "sha512-P1hSfcc2HJYT5t+WPu/11OfFMa7m8pBb2Gf2vm6W9OVs7YTXQ5RCC3nDqaYZQaTqxEM1ZZaTcQGcE6U2xMOsqQ==",
+			"dev": true,
+			"requires": {
+				"browser-resolve": "1.11.2",
+				"chalk": "2.3.1"
+			}
+		},
+		"jest-resolve-dependencies": {
+			"version": "22.1.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-22.1.0.tgz",
+			"integrity": "sha512-76Ll61bD/Sus8wK8d+lw891EtiBJGJkWG8OuVDTEX0z3z2+jPujvQqSB2eQ+kCHyCsRwJ2PSjhn3UHqae/oEtA==",
+			"dev": true,
+			"requires": {
+				"jest-regex-util": "22.1.0"
+			}
+		},
+		"jest-runner": {
+			"version": "22.4.2",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.4.2.tgz",
+			"integrity": "sha512-W4vwgiVQS0NyXt8hgpw7i0YUtsfoChiQcoHWBJeq2ocV4VF2osEZx8HYgpH5HfNe1Cb5LZeZWxX8Dr3hesbGFg==",
+			"dev": true,
+			"requires": {
+				"exit": "0.1.2",
+				"jest-config": "22.4.2",
+				"jest-docblock": "22.4.0",
+				"jest-haste-map": "22.4.2",
+				"jest-jasmine2": "22.4.2",
+				"jest-leak-detector": "22.4.0",
+				"jest-message-util": "22.4.0",
+				"jest-runtime": "22.4.2",
+				"jest-util": "22.4.1",
+				"jest-worker": "22.2.2",
+				"throat": "4.1.0"
+			}
+		},
+		"jest-runtime": {
+			"version": "22.4.2",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.4.2.tgz",
+			"integrity": "sha512-9/Fxbj99cqxI7o2nTNzevnI38eDBstkwve8ZeaAD/Kz0fbU3i3eRv2QPEmzbmyCyBvUWxCT7BzNLTzTqH1+pyA==",
+			"dev": true,
+			"requires": {
+				"babel-core": "6.26.0",
+				"babel-jest": "22.4.1",
+				"babel-plugin-istanbul": "4.1.5",
+				"chalk": "2.3.1",
+				"convert-source-map": "1.5.1",
+				"exit": "0.1.2",
+				"graceful-fs": "4.1.11",
+				"jest-config": "22.4.2",
+				"jest-haste-map": "22.4.2",
+				"jest-regex-util": "22.1.0",
+				"jest-resolve": "22.4.2",
+				"jest-util": "22.4.1",
+				"jest-validate": "22.4.2",
+				"json-stable-stringify": "1.0.1",
+				"micromatch": "2.3.11",
+				"realpath-native": "1.0.0",
+				"slash": "1.0.0",
+				"strip-bom": "3.0.0",
+				"write-file-atomic": "2.3.0",
+				"yargs": "10.1.2"
+			},
+			"dependencies": {
+				"strip-bom": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+					"dev": true
+				}
+			}
+		},
+		"jest-serializer": {
+			"version": "22.4.0",
+			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-22.4.0.tgz",
+			"integrity": "sha512-dnqde95MiYfdc1ZJpjEiHCRvRGGJHPsZQARJFucEGIaOzxqqS9/tt2WzD/OUSGT6kxaEGLQE92faVJGdoCu+Rw==",
+			"dev": true
+		},
+		"jest-snapshot": {
+			"version": "22.4.0",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.4.0.tgz",
+			"integrity": "sha512-6Zz4F9G1Nbr93kfm5h3A2+OkE+WGpgJlskYE4iSNN2uYfoTL5b9W6aB9Orpx+ueReHyqmy7HET7Z3EmYlL3hKw==",
+			"dev": true,
+			"requires": {
+				"chalk": "2.3.1",
+				"jest-diff": "22.4.0",
+				"jest-matcher-utils": "22.4.0",
+				"mkdirp": "0.5.1",
+				"natural-compare": "1.4.0",
+				"pretty-format": "22.4.0"
+			}
+		},
+		"jest-util": {
+			"version": "22.4.1",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.4.1.tgz",
+			"integrity": "sha512-9ySBdJY2qVWpg0OvZbGcFXE2NgwccpZVj384E9bx7brKFc7l5anpqah15mseWcz7FLDk7/N+LyYgqFme7Rez2Q==",
+			"dev": true,
+			"requires": {
+				"callsites": "2.0.0",
+				"chalk": "2.3.1",
+				"graceful-fs": "4.1.11",
+				"is-ci": "1.1.0",
+				"jest-message-util": "22.4.0",
+				"mkdirp": "0.5.1",
+				"source-map": "0.6.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
+			}
+		},
+		"jest-validate": {
+			"version": "22.4.2",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.2.tgz",
+			"integrity": "sha512-TLOgc/EULFBjMCAqZp5OdVvjxV16DZpfthd/UyPzM6lRmgWluohNVemAdnL3JvugU1s2Q2npcIqtbOtiPjaZ0A==",
+			"dev": true,
+			"requires": {
+				"chalk": "2.3.1",
+				"jest-config": "22.4.2",
+				"jest-get-type": "22.1.0",
+				"leven": "2.1.0",
+				"pretty-format": "22.4.0"
+			}
+		},
+		"jest-worker": {
+			"version": "22.2.2",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-22.2.2.tgz",
+			"integrity": "sha512-ZylDXjrFNt/OP6cUxwJFWwDgazP7hRjtCQbocFHyiwov+04Wm1x5PYzMGNJT53s4nwr0oo9ocYTImS09xOlUnw==",
+			"dev": true,
+			"requires": {
+				"merge-stream": "1.0.1"
+			}
+		},
+		"js-tokens": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+			"dev": true
+		},
+		"js-yaml": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+			"integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+			"dev": true,
+			"requires": {
+				"argparse": "1.0.10",
+				"esprima": "4.0.0"
+			}
+		},
+		"jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"dev": true,
+			"optional": true
+		},
+		"jsdom": {
+			"version": "11.6.2",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.6.2.tgz",
+			"integrity": "sha512-pAeZhpbSlUp5yQcS6cBQJwkbzmv4tWFaYxHbFVSxzXefqjvtRA851Z5N2P+TguVG9YeUDcgb8pdeVQRJh0XR3Q==",
+			"dev": true,
+			"requires": {
+				"abab": "1.0.4",
+				"acorn": "5.4.1",
+				"acorn-globals": "4.1.0",
+				"array-equal": "1.0.0",
+				"browser-process-hrtime": "0.1.2",
+				"content-type-parser": "1.0.2",
+				"cssom": "0.3.2",
+				"cssstyle": "0.2.37",
+				"domexception": "1.0.1",
+				"escodegen": "1.9.1",
+				"html-encoding-sniffer": "1.0.2",
+				"left-pad": "1.2.0",
+				"nwmatcher": "1.4.3",
+				"parse5": "4.0.0",
+				"pn": "1.1.0",
+				"request": "2.83.0",
+				"request-promise-native": "1.0.5",
+				"sax": "1.2.4",
+				"symbol-tree": "3.2.2",
+				"tough-cookie": "2.3.3",
+				"w3c-hr-time": "1.0.1",
+				"webidl-conversions": "4.0.2",
+				"whatwg-encoding": "1.0.3",
+				"whatwg-url": "6.4.0",
+				"ws": "4.1.0",
+				"xml-name-validator": "3.0.0"
+			}
+		},
+		"jsesc": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+			"dev": true
+		},
+		"json-schema": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+			"dev": true
+		},
+		"json-schema-traverse": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+			"dev": true
+		},
+		"json-stable-stringify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+			"dev": true,
+			"requires": {
+				"jsonify": "0.0.0"
+			}
+		},
+		"json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"dev": true
+		},
+		"json5": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+			"dev": true
+		},
+		"jsonify": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+			"dev": true
+		},
+		"jsprim": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "1.0.0",
+				"extsprintf": "1.3.0",
+				"json-schema": "0.2.3",
+				"verror": "1.10.0"
+			}
+		},
+		"kind-of": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"dev": true,
+			"requires": {
+				"is-buffer": "1.1.6"
+			}
+		},
+		"lazy-cache": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+			"dev": true,
+			"optional": true
+		},
+		"lcid": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+			"dev": true,
+			"requires": {
+				"invert-kv": "1.0.0"
+			}
+		},
+		"left-pad": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.2.0.tgz",
+			"integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4=",
+			"dev": true
+		},
+		"leven": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+			"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+			"dev": true
+		},
+		"levn": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"dev": true,
+			"requires": {
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2"
+			}
+		},
+		"load-json-file": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"parse-json": "2.2.0",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1",
+				"strip-bom": "2.0.0"
+			}
+		},
+		"locate-path": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+			"dev": true,
+			"requires": {
+				"p-locate": "2.0.0",
+				"path-exists": "3.0.0"
+			}
+		},
+		"lodash": {
+			"version": "4.17.5",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+			"dev": true
+		},
+		"lodash.sortby": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+			"dev": true
+		},
+		"longest": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+			"dev": true
+		},
+		"loose-envify": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+			"dev": true,
+			"requires": {
+				"js-tokens": "3.0.2"
+			}
+		},
+		"lru-cache": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+			"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+			"dev": true,
+			"requires": {
+				"pseudomap": "1.0.2",
+				"yallist": "2.1.2"
+			}
+		},
+		"makeerror": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+			"integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+			"dev": true,
+			"requires": {
+				"tmpl": "1.0.4"
+			}
+		},
+		"mem": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+			"dev": true,
+			"requires": {
+				"mimic-fn": "1.2.0"
+			}
+		},
+		"merge": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+			"integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
+			"dev": true
+		},
+		"merge-stream": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+			"dev": true,
+			"requires": {
+				"readable-stream": "2.3.4"
+			}
+		},
+		"micromatch": {
+			"version": "2.3.11",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+			"dev": true,
+			"requires": {
+				"arr-diff": "2.0.0",
+				"array-unique": "0.2.1",
+				"braces": "1.8.5",
+				"expand-brackets": "0.1.5",
+				"extglob": "0.3.2",
+				"filename-regex": "2.0.1",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1",
+				"kind-of": "3.2.2",
+				"normalize-path": "2.1.1",
+				"object.omit": "2.0.1",
+				"parse-glob": "3.0.4",
+				"regex-cache": "0.4.4"
+			}
+		},
+		"mime-db": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+			"dev": true
+		},
+		"mime-types": {
+			"version": "2.1.18",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+			"dev": true,
+			"requires": {
+				"mime-db": "1.33.0"
+			}
+		},
+		"mimic-fn": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+			"dev": true
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
+			"requires": {
+				"brace-expansion": "1.1.11"
+			}
+		},
+		"minimist": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+			"dev": true
+		},
+		"mkdirp": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"dev": true,
+			"requires": {
+				"minimist": "0.0.8"
+			}
+		},
+		"ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
+		},
+		"nan": {
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
+			"integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
+			"dev": true,
+			"optional": true
+		},
+		"natural-compare": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+			"dev": true
+		},
+		"node-int64": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+			"dev": true
+		},
+		"node-notifier": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
+			"integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
+			"dev": true,
+			"requires": {
+				"growly": "1.3.0",
+				"semver": "5.5.0",
+				"shellwords": "0.1.1",
+				"which": "1.3.0"
+			}
+		},
+		"normalize-package-data": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+			"dev": true,
+			"requires": {
+				"hosted-git-info": "2.5.0",
+				"is-builtin-module": "1.0.0",
+				"semver": "5.5.0",
+				"validate-npm-package-license": "3.0.1"
+			}
+		},
+		"normalize-path": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"dev": true,
+			"requires": {
+				"remove-trailing-separator": "1.1.0"
+			}
+		},
+		"npm-run-path": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+			"dev": true,
+			"requires": {
+				"path-key": "2.0.1"
+			}
+		},
+		"number-is-nan": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+			"dev": true
+		},
+		"nwmatcher": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.3.tgz",
+			"integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw==",
+			"dev": true
+		},
+		"oauth-sign": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+			"dev": true
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"dev": true
+		},
+		"object-keys": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+			"dev": true
+		},
+		"object.getownpropertydescriptors": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+			"dev": true,
+			"requires": {
+				"define-properties": "1.1.2",
+				"es-abstract": "1.10.0"
+			}
+		},
+		"object.omit": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+			"dev": true,
+			"requires": {
+				"for-own": "0.1.5",
+				"is-extendable": "0.1.1"
+			}
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
+			"requires": {
+				"wrappy": "1.0.2"
+			}
+		},
+		"optimist": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+			"dev": true,
+			"requires": {
+				"minimist": "0.0.8",
+				"wordwrap": "0.0.3"
+			}
+		},
+		"optionator": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"dev": true,
+			"requires": {
+				"deep-is": "0.1.3",
+				"fast-levenshtein": "2.0.6",
+				"levn": "0.3.0",
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2",
+				"wordwrap": "1.0.0"
+			},
+			"dependencies": {
+				"wordwrap": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+					"dev": true
+				}
+			}
+		},
+		"os-homedir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+			"dev": true
+		},
+		"os-locale": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+			"dev": true,
+			"requires": {
+				"execa": "0.7.0",
+				"lcid": "1.0.0",
+				"mem": "1.1.0"
+			}
+		},
+		"os-tmpdir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+			"dev": true
+		},
+		"p-finally": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+			"dev": true
+		},
+		"p-limit": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+			"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+			"dev": true,
+			"requires": {
+				"p-try": "1.0.0"
+			}
+		},
+		"p-locate": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+			"dev": true,
+			"requires": {
+				"p-limit": "1.2.0"
+			}
+		},
+		"p-try": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+			"dev": true
+		},
+		"parse-glob": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+			"dev": true,
+			"requires": {
+				"glob-base": "0.3.0",
+				"is-dotfile": "1.0.3",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1"
+			}
+		},
+		"parse-json": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+			"dev": true,
+			"requires": {
+				"error-ex": "1.3.1"
+			}
+		},
+		"parse5": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+			"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+			"dev": true
+		},
+		"path-exists": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+			"dev": true
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
+		},
+		"path-key": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+			"dev": true
+		},
+		"path-parse": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+			"dev": true
+		},
+		"path-type": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1"
+			}
+		},
+		"performance-now": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+			"dev": true
+		},
+		"pify": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+			"dev": true
+		},
+		"pinkie": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+			"dev": true
+		},
+		"pinkie-promise": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"dev": true,
+			"requires": {
+				"pinkie": "2.0.4"
+			}
+		},
+		"pkg-dir": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+			"dev": true,
+			"requires": {
+				"find-up": "2.1.0"
+			}
+		},
+		"pn": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+			"dev": true
+		},
+		"prelude-ls": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"dev": true
+		},
+		"preserve": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+			"dev": true
+		},
+		"pretty-format": {
+			"version": "22.4.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.0.tgz",
+			"integrity": "sha512-pvCxP2iODIIk9adXlo4S3GRj0BrJiil68kByAa1PrgG97c1tClh9dLMgp3Z6cHFZrclaABt0UH8PIhwHuFLqYA==",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "3.0.0",
+				"ansi-styles": "3.2.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				}
+			}
+		},
+		"private": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+			"dev": true
+		},
+		"process-nextick-args": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+			"dev": true
+		},
+		"pseudomap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+			"dev": true
+		},
+		"punycode": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+			"dev": true
+		},
+		"qs": {
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+			"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+			"dev": true
+		},
+		"randomatic": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+			"dev": true,
+			"requires": {
+				"is-number": "3.0.0",
+				"kind-of": "4.0.0"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"kind-of": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "1.1.6"
+					}
+				}
+			}
+		},
+		"read-pkg": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+			"dev": true,
+			"requires": {
+				"load-json-file": "1.1.0",
+				"normalize-package-data": "2.4.0",
+				"path-type": "1.1.0"
+			}
+		},
+		"read-pkg-up": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+			"dev": true,
+			"requires": {
+				"find-up": "1.1.2",
+				"read-pkg": "1.1.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"dev": true,
+					"requires": {
+						"path-exists": "2.1.0",
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"dev": true,
+					"requires": {
+						"pinkie-promise": "2.0.1"
+					}
+				}
+			}
+		},
+		"readable-stream": {
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
+			"integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+			"dev": true,
+			"requires": {
+				"core-util-is": "1.0.2",
+				"inherits": "2.0.3",
+				"isarray": "1.0.0",
+				"process-nextick-args": "2.0.0",
+				"safe-buffer": "5.1.1",
+				"string_decoder": "1.0.3",
+				"util-deprecate": "1.0.2"
+			}
+		},
+		"realpath-native": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.0.tgz",
+			"integrity": "sha512-XJtlRJ9jf0E1H1SLeJyQ9PGzQD7S65h1pRXEcAeK48doKOnKxcgPeNohJvD5u/2sI9J1oke6E8bZHS/fmW1UiQ==",
+			"dev": true,
+			"requires": {
+				"util.promisify": "1.0.0"
+			}
+		},
+		"regenerator-runtime": {
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+			"dev": true
+		},
+		"regex-cache": {
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+			"dev": true,
+			"requires": {
+				"is-equal-shallow": "0.1.3"
+			}
+		},
+		"remove-trailing-separator": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+			"dev": true
+		},
+		"repeat-element": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+			"dev": true
+		},
+		"repeat-string": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+			"dev": true
+		},
+		"repeating": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+			"dev": true,
+			"requires": {
+				"is-finite": "1.0.2"
+			}
+		},
+		"request": {
+			"version": "2.83.0",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+			"integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+			"dev": true,
+			"requires": {
+				"aws-sign2": "0.7.0",
+				"aws4": "1.6.0",
+				"caseless": "0.12.0",
+				"combined-stream": "1.0.6",
+				"extend": "3.0.1",
+				"forever-agent": "0.6.1",
+				"form-data": "2.3.2",
+				"har-validator": "5.0.3",
+				"hawk": "6.0.2",
+				"http-signature": "1.2.0",
+				"is-typedarray": "1.0.0",
+				"isstream": "0.1.2",
+				"json-stringify-safe": "5.0.1",
+				"mime-types": "2.1.18",
+				"oauth-sign": "0.8.2",
+				"performance-now": "2.1.0",
+				"qs": "6.5.1",
+				"safe-buffer": "5.1.1",
+				"stringstream": "0.0.5",
+				"tough-cookie": "2.3.3",
+				"tunnel-agent": "0.6.0",
+				"uuid": "3.2.1"
+			}
+		},
+		"request-promise-core": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+			"dev": true,
+			"requires": {
+				"lodash": "4.17.5"
+			}
+		},
+		"request-promise-native": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+			"integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+			"dev": true,
+			"requires": {
+				"request-promise-core": "1.1.1",
+				"stealthy-require": "1.1.1",
+				"tough-cookie": "2.3.3"
+			}
+		},
+		"require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+			"dev": true
+		},
+		"require-main-filename": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+			"dev": true
+		},
+		"resolve": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+			"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+			"dev": true
+		},
+		"resolve-cwd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+			"dev": true,
+			"requires": {
+				"resolve-from": "3.0.0"
+			}
+		},
+		"resolve-from": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+			"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+			"dev": true
+		},
+		"right-align": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"align-text": "0.1.4"
+			}
+		},
+		"rimraf": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+			"dev": true,
+			"requires": {
+				"glob": "7.1.2"
+			}
+		},
+		"safe-buffer": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+			"dev": true
+		},
+		"sane": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/sane/-/sane-2.4.1.tgz",
+			"integrity": "sha512-fW9svvNd81XzHDZyis9/tEY1bZikDGryy8Hi1BErPyNPYv47CdLseUN+tI5FBHWXEENRtj1SWtX/jBnggLaP0w==",
+			"dev": true,
+			"requires": {
+				"anymatch": "1.3.2",
+				"exec-sh": "0.2.1",
+				"fb-watchman": "2.0.0",
+				"fsevents": "1.1.3",
+				"minimatch": "3.0.4",
+				"minimist": "1.2.0",
+				"walker": "1.0.7",
+				"watch": "0.18.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				}
+			}
+		},
+		"sax": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+			"dev": true
+		},
+		"semver": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+			"dev": true
+		},
+		"set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+			"dev": true
+		},
+		"shebang-command": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+			"dev": true,
+			"requires": {
+				"shebang-regex": "1.0.0"
+			}
+		},
+		"shebang-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+			"dev": true
+		},
+		"shellwords": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+			"dev": true
+		},
+		"signal-exit": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+			"dev": true
+		},
+		"slash": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+			"dev": true
+		},
+		"sntp": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+			"dev": true,
+			"requires": {
+				"hoek": "4.2.1"
+			}
+		},
+		"source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"dev": true
+		},
+		"source-map-support": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.3.tgz",
+			"integrity": "sha512-eKkTgWYeBOQqFGXRfKabMFdnWepo51vWqEdoeikaEPFiJC7MCU5j2h4+6Q8npkZTeLGbSyecZvRxiSoWl3rh+w==",
+			"dev": true,
+			"requires": {
+				"source-map": "0.6.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
+			}
+		},
+		"spdx-correct": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+			"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+			"dev": true,
+			"requires": {
+				"spdx-license-ids": "1.2.2"
+			}
+		},
+		"spdx-expression-parse": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+			"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+			"dev": true
+		},
+		"spdx-license-ids": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+			"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+			"dev": true
+		},
+		"sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
+		},
+		"sshpk": {
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+			"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+			"dev": true,
+			"requires": {
+				"asn1": "0.2.3",
+				"assert-plus": "1.0.0",
+				"bcrypt-pbkdf": "1.0.1",
+				"dashdash": "1.14.1",
+				"ecc-jsbn": "0.1.1",
+				"getpass": "0.1.7",
+				"jsbn": "0.1.1",
+				"tweetnacl": "0.14.5"
+			}
+		},
+		"stack-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
+			"integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
+			"dev": true
+		},
+		"stealthy-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+			"dev": true
+		},
+		"string-length": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
+			"integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
+			"dev": true,
+			"requires": {
+				"astral-regex": "1.0.0",
+				"strip-ansi": "4.0.0"
+			}
+		},
+		"string-width": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"dev": true,
+			"requires": {
+				"is-fullwidth-code-point": "2.0.0",
+				"strip-ansi": "4.0.0"
+			}
+		},
+		"string_decoder": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"stringstream": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+			"dev": true
+		},
+		"strip-ansi": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "3.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				}
+			}
+		},
+		"strip-bom": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+			"dev": true,
+			"requires": {
+				"is-utf8": "0.2.1"
+			}
+		},
+		"strip-eof": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+			"dev": true
+		},
+		"supports-color": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+			"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+			"dev": true,
+			"requires": {
+				"has-flag": "3.0.0"
+			}
+		},
+		"symbol-tree": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+			"dev": true
+		},
+		"test-exclude": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.0.tgz",
+			"integrity": "sha512-8hMFzjxbPv6xSlwGhXSvOMJ/vTy3bkng+2pxmf6E1z6VF7I9nIyNfvHtaw+NBPgvz647gADBbMSbwLfZYppT/w==",
+			"dev": true,
+			"requires": {
+				"arrify": "1.0.1",
+				"micromatch": "2.3.11",
+				"object-assign": "4.1.1",
+				"read-pkg-up": "1.0.1",
+				"require-main-filename": "1.0.1"
+			}
+		},
+		"throat": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
+			"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
+			"dev": true
+		},
+		"tmpl": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+			"integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+			"dev": true
+		},
+		"to-fast-properties": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+			"dev": true
+		},
+		"tough-cookie": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+			"integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+			"dev": true,
+			"requires": {
+				"punycode": "1.4.1"
+			}
+		},
+		"tr46": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+			"dev": true,
+			"requires": {
+				"punycode": "2.1.0"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+					"integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
+					"dev": true
+				}
+			}
+		},
+		"trim-right": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+			"dev": true
+		},
+		"tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"tweetnacl": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"dev": true,
+			"optional": true
+		},
+		"type-check": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"dev": true,
+			"requires": {
+				"prelude-ls": "1.1.2"
+			}
+		},
+		"uglify-js": {
+			"version": "2.8.29",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+			"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"source-map": "0.5.7",
+				"uglify-to-browserify": "1.0.2",
+				"yargs": "3.10.0"
+			},
+			"dependencies": {
+				"yargs": {
+					"version": "3.10.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"camelcase": "1.2.1",
+						"cliui": "2.1.0",
+						"decamelize": "1.2.0",
+						"window-size": "0.1.0"
+					}
+				}
+			}
+		},
+		"uglify-to-browserify": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+			"dev": true,
+			"optional": true
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
+		},
+		"util.promisify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+			"dev": true,
+			"requires": {
+				"define-properties": "1.1.2",
+				"object.getownpropertydescriptors": "2.0.3"
+			}
+		},
+		"uuid": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+			"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+			"dev": true
+		},
+		"validate-npm-package-license": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+			"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+			"dev": true,
+			"requires": {
+				"spdx-correct": "1.0.2",
+				"spdx-expression-parse": "1.0.4"
+			}
+		},
+		"verror": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "1.0.0",
+				"core-util-is": "1.0.2",
+				"extsprintf": "1.3.0"
+			}
+		},
+		"w3c-hr-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+			"dev": true,
+			"requires": {
+				"browser-process-hrtime": "0.1.2"
+			}
+		},
+		"walker": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+			"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+			"dev": true,
+			"requires": {
+				"makeerror": "1.0.11"
+			}
+		},
+		"watch": {
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
+			"integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
+			"dev": true,
+			"requires": {
+				"exec-sh": "0.2.1",
+				"minimist": "1.2.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				}
+			}
+		},
+		"webidl-conversions": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+			"dev": true
+		},
+		"whatwg-encoding": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
+			"integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
+			"dev": true,
+			"requires": {
+				"iconv-lite": "0.4.19"
+			}
+		},
+		"whatwg-url": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
+			"integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
+			"dev": true,
+			"requires": {
+				"lodash.sortby": "4.7.0",
+				"tr46": "1.0.1",
+				"webidl-conversions": "4.0.2"
+			}
+		},
+		"which": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+			"dev": true,
+			"requires": {
+				"isexe": "2.0.0"
+			}
+		},
+		"which-module": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+			"dev": true
+		},
+		"window-size": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+			"dev": true,
+			"optional": true
+		},
+		"wordwrap": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+			"dev": true
+		},
+		"wrap-ansi": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+			"dev": true,
+			"requires": {
+				"string-width": "1.0.2",
+				"strip-ansi": "3.0.1"
+			},
+			"dependencies": {
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"dev": true,
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"dev": true,
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				}
+			}
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
+		},
+		"write-file-atomic": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
+			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"imurmurhash": "0.1.4",
+				"signal-exit": "3.0.2"
+			}
+		},
+		"ws": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+			"integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
+			"dev": true,
+			"requires": {
+				"async-limiter": "1.0.0",
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"xml-name-validator": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+			"dev": true
+		},
+		"y18n": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+			"dev": true
+		},
+		"yallist": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+			"dev": true
+		},
+		"yargs": {
+			"version": "10.1.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
+			"integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
+			"dev": true,
+			"requires": {
+				"cliui": "4.0.0",
+				"decamelize": "1.2.0",
+				"find-up": "2.1.0",
+				"get-caller-file": "1.0.2",
+				"os-locale": "2.1.0",
+				"require-directory": "2.1.1",
+				"require-main-filename": "1.0.1",
+				"set-blocking": "2.0.0",
+				"string-width": "2.1.1",
+				"which-module": "2.0.0",
+				"y18n": "3.2.1",
+				"yargs-parser": "8.1.0"
+			},
+			"dependencies": {
+				"cliui": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
+					"integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+					"dev": true,
+					"requires": {
+						"string-width": "2.1.1",
+						"strip-ansi": "4.0.0",
+						"wrap-ansi": "2.1.0"
+					}
+				}
+			}
+		},
+		"yargs-parser": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
+			"integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+			"dev": true,
+			"requires": {
+				"camelcase": "4.1.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+					"dev": true
+				}
+			}
+		}
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3207,6 +3207,11 @@
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
 		},
+		"node-dogstatsd": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/node-dogstatsd/-/node-dogstatsd-0.0.6.tgz",
+			"integrity": "sha1-1pfk0ZA6f/DBZHnNXRzeBDc34Ec="
+		},
 		"node-int64": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -1,20 +1,20 @@
 {
 	"name": "connect-datadog",
-	"version": "0.0.4",
+	"version": "0.0.7",
 	"description": "Datadog middleware for Connect JS / Express",
 	"main": "index.js",
 	"repository": {
 		"type": "git",
-		"url": "git://github.com/AppPress/node-connect-datadog.git"
+		"url": "git://github.com/DataDog/node-connect-datadog.git"
 	},
 	"keywords": [
 		"datadog",
 		"middleware"
 	],
-	"author": "App Press",
+	"author": "Datadog",
 	"license": "MIT",
 	"readmeFilename": "README.md",
 	"dependencies": {
-		"node-dogstatsd": "0.0.5"
+		"node-dogstatsd": "0.0.6"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
 		"type": "git",
 		"url": "git://github.com/DataDog/node-connect-datadog.git"
 	},
+	"scripts": {
+		"test": "jest"
+	},
 	"keywords": [
 		"datadog",
 		"middleware"
@@ -16,5 +19,8 @@
 	"readmeFilename": "README.md",
 	"dependencies": {
 		"node-dogstatsd": "0.0.6"
+	},
+	"devDependencies": {
+		"jest": "^22.4.2"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
 	"name": "connect-datadog",
-	"version": "0.0.7",
+	"version": "0.0.5",
 	"description": "Datadog middleware for Connect JS / Express",
 	"main": "index.js",
 	"repository": {
 		"type": "git",
-		"url": "git://github.com/DataDog/node-connect-datadog.git"
+		"url": "git://github.com/AppPress/node-connect-datadog.git"
 	},
 	"scripts": {
 		"test": "jest"
@@ -14,7 +14,7 @@
 		"datadog",
 		"middleware"
 	],
-	"author": "Datadog",
+	"author": "App Press",
 	"license": "MIT",
 	"readmeFilename": "README.md",
 	"dependencies": {


### PR DESCRIPTION
Metrics sent through connect-datadog cannot contain a route with a pipe character, since the pipe character is used as a delimiter. This fix replaces the pipe character with a configurable replacement character.

We also introduce a few additional improvements, including:

Ability to append the baseUrl to the path in the tags
A new unit test suite with Jest.